### PR TITLE
Fix - Decimal handling when saving paper dimensions

### DIFF
--- a/java/src/main/java/com/marginallyclever/makelangeloRobot/settings/PanelAdjustPaper.java
+++ b/java/src/main/java/com/marginallyclever/makelangeloRobot/settings/PanelAdjustPaper.java
@@ -288,8 +288,8 @@ implements ActionListener, PropertyChangeListener, ChangeListener {
 	}
 	
 	public void save() {
-		double pwf = Double.valueOf(pw.getText());
-		double phf = Double.valueOf(ph.getText());
+		double pwf = ((Number)pw.getValue()).doubleValue();
+		double phf = ((Number)ph.getValue()).doubleValue();
 		
 		boolean data_is_sane=true;
 		if( pwf<=0 ) data_is_sane=false;


### PR DESCRIPTION
My locale uses commas instead of dots as separator for decimal numbers. Because of this, I was getting the following error when saving a configuration:

```
Exception in thread "AWT-EventQueue-0" java.lang.NumberFormatException: For input string: "420,0"
	at sun.misc.FloatingDecimal.readJavaFormatString(Unknown Source)
	at sun.misc.FloatingDecimal.parseDouble(Unknown Source)
	at java.lang.Double.parseDouble(Unknown Source)
	at java.lang.Double.valueOf(Unknown Source)
	at com.marginallyclever.makelangeloRobot.settings.PanelAdjustPaper.save(PanelAdjustPaper.java:291)
	...
```

I modified the method after checking how decimal values is handled in other parts of the code.