### PR TITLE
Reduce CPU usage

### DIFF
--- a/src/main/com/marginallyclever/makelangelo/DrawPanel.java
+++ b/src/main/com/marginallyclever/makelangelo/DrawPanel.java
@@ -153,6 +153,8 @@ public class DrawPanel extends GLJPanel implements MouseListener, MouseInputList
 		}
 		cameraOffsetX = 0;
 		cameraOffsetY = 0;
+		
+		repaint();
 	}
 
 	public void mousePressed(MouseEvent e) {
@@ -196,6 +198,7 @@ public class DrawPanel extends GLJPanel implements MouseListener, MouseInputList
 	private void moveCamera(int dx, int dy) {
 		cameraOffsetX += (float) dx * cameraZoom / windowWidth;
 		cameraOffsetY += (float) dy * cameraZoom / windowHeight;
+		repaint();
 	}
 
 	/**
@@ -209,6 +212,8 @@ public class DrawPanel extends GLJPanel implements MouseListener, MouseInputList
 		cameraZoom += zoomAmount;
 		if (cameraZoom < 0.1)
 			cameraZoom = 0.1;
+		
+		repaint();
 	}
 
 	/**
@@ -217,6 +222,8 @@ public class DrawPanel extends GLJPanel implements MouseListener, MouseInputList
 	public void zoomIn() {
 		cameraZoom *= 3.5d / 4.0d;
 		if(cameraZoom<CAMERA_ZNEAR) cameraZoom=CAMERA_ZNEAR;
+		
+		repaint();
 	}
 
 	/**
@@ -225,6 +232,8 @@ public class DrawPanel extends GLJPanel implements MouseListener, MouseInputList
 	public void zoomOut() {
 		cameraZoom *= 4.0d / 3.5d;
 		if(cameraZoom>CAMERA_ZFAR) cameraZoom=CAMERA_ZFAR;
+		
+		repaint();
 	}
 
 	public double getZoom() {

--- a/src/main/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/com/marginallyclever/makelangelo/Makelangelo.java
@@ -434,7 +434,7 @@ public final class Makelangelo
 
 		// start animation system
 		Log.message("  starting animator...");
-		animator = new FPSAnimator(20);
+		animator = new FPSAnimator(1);
 		animator.add(drawPanel);
 		animator.start();
 	}


### PR DESCRIPTION
Makelangelo takes up 160% CPU usage on my MacBook Pro, when it's basically idle. The FPSAnimator which repaints the drawPanel at 20fps is wasting lots of resources. Most of the time nothing has changed and the drawPanel doesn't need to be repainted.

I now reduced the framerate to 1 repaint per second, so the interface will continue to be updated (albeit with slight lag). But I've added explicit calls to repaint() when certain events occur, like dragging the viewport, or zooming. That way, these events will repaint immediately, there won't be any lag, and we won't be constantly repainting when nothing changed.

Ideally the FPSAnimator would be removed completely, and all events (like the manual driving commands) would call repaint().

With the changes in this pull request the CPU usage dropped to 15%. Now I can keep Makelangelo open more comfortably.