### PR TITLE
Deduplicate by merging overlapping lines

### DIFF
--- a/src/test/resources/dedupe_test.svg
+++ b/src/test/resources/dedupe_test.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 2834.6 2834.6" style="enable-background:new 0 0 2834.6 2834.6;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#000000;stroke-width:13;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#ED1C24;stroke-width:13;stroke-miterlimit:10;}
+</style>
+<line class="st0" x1="1341.9" y1="239.4" x2="1341.9" y2="1883.6"/>
+<line class="st1" x1="1341.9" y1="1492.5" x2="1341.9" y2="588.1"/>
+<line class="st1" x1="2161.8" y1="1657.2" x2="2161.8" y2="255.2"/>
+<line class="st1" x1="68.9" y1="559.6" x2="647.5" y2="559.6"/>
+<line class="st0" x1="2161.8" y1="1852.2" x2="2161.8" y2="427.3"/>
+<line class="st0" x1="478.9" y1="559.6" x2="1057.5" y2="559.6"/>
+<line class="st1" x1="698.9" y1="559.6" x2="1277.5" y2="559.6"/>
+<line class="st0" x1="246.3" y1="854.8" x2="634.5" y2="2283.7"/>
+<line class="st1" x1="327.2" y1="1152.5" x2="576.8" y2="2071.4"/>
+<line class="st0" x1="2140.4" y1="2198.1" x2="1232.7" y2="2198.1"/>
+<line class="st1" x1="875" y1="2198.1" x2="1686.6" y2="2198.1"/>
+<line class="st0" x1="1955.1" y1="1750.7" x2="1313.3" y2="2392.5"/>
+<line class="st1" x1="1060.3" y1="2645.5" x2="1634.2" y2="2071.6"/>
+<line class="st1" x1="2192.9" y1="1904.1" x2="1553.1" y2="2531.6"/>
+<line class="st0" x1="1444.3" y1="2638.2" x2="2097.9" y2="1997.3"/>
+<line class="st0" x1="2411" y1="1476.4" x2="1979.9" y2="1045.3"/>
+<line class="st1" x1="1869.8" y1="935.2" x2="2245.1" y2="1310.5"/>
+</svg>


### PR DESCRIPTION
Hi Dan, I hope you like this pull request.

I was able to optimize further by merging overlapping lines.

New real world drawing time of reorder_test.svg:

`12m8s 4757 / 4757 100.00%`

Compared to previous time:

`16m19s 13193 / 13193 100.00%`

And that's with a lower `EPSILON_CONNECTED` value, meaning actual performance gain is a bit higher still. But I found the current value of 2 to skip too many pen up moves.

If I had kept `EPSILON_CONNECTED` set to 2, then the score would be:
`11m46s 4670 / 4670 100.00%`

I've added a test SVG as well, to demonstrate the benefits.