### PR TITLE
Simplify

### DIFF
--- a/src/main/com/marginallyclever/convenience/Turtle.java
+++ b/src/main/com/marginallyclever/convenience/Turtle.java
@@ -3,7 +3,6 @@ package com.marginallyclever.convenience;
 import java.util.ArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.marginallyclever.convenience.Turtle.MoveType;
 import com.marginallyclever.convenience.log.Log;
 
 
@@ -19,7 +18,7 @@ public class Turtle {
 		TOOL_CHANGE;
 	}
 	
-	public class Movement {
+	public static class Movement {
 		public MoveType type;
 		public double x,y;  // destination
 		

--- a/src/main/com/marginallyclever/makelangeloRobot/MakelangeloRobot.java
+++ b/src/main/com/marginallyclever/makelangeloRobot/MakelangeloRobot.java
@@ -932,7 +932,7 @@ public class MakelangeloRobot implements NetworkConnectionListener {
 				boolean isUp = true;
 				double ox = settings.getHomeX();
 				double oy = settings.getHomeY();
-				Movement previousMove = turtle.new Movement(ox, oy, Turtle.MoveType.TRAVEL);
+				Movement previousMove = new Movement(ox, oy, Turtle.MoveType.TRAVEL);
 
 				int first = 0;
 				int last = turtle.history.size();


### PR DESCRIPTION
This is my implementation of simplify called simplify1. Its a mixture of your simplify and reorder and not activated in this PR.
It use Quadtree's to store points, so its very efficient storing lots of points. (believe its O(N*log(N) )
This implementation  knows which line segment ends sit at the same point but it does not know which line ends are near by
as it would require a O(N^2) operation.
It can simplify duplicate parallel and antiparallal lines, but not partially overlapped lines with neither point coincident .
Finally it also reorders the points while requesting each pen change only once.
It has comparable results to yours but i believe its more efficient for huge amounts of data.

