### PR TITLE
Update kabeja groupId according to local repo structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@ It pairs really well with Makelangelo-firmware, the code in the brain of the rob
 
 		<!-- https://mvnrepository.com/artifact/net.sourceforge/kabeja -->
 		<dependency>
-			<groupId>net.sourceforge</groupId>
+			<groupId>org.kabeja</groupId>
 			<artifactId>kabeja</artifactId>
 			<version>0.4</version>
 		</dependency>


### PR DESCRIPTION
Hi, 

Thanks for your work.

Here is a fix for maven in order to package the app on a fresh install. The groupId is changed to match the file stored in `java/local-maven-repo/org/kabeja/kabeja/0.4/kabeja-0.4.jar`

Otherwise, it fails with : 
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.641 s
[INFO] Finished at: 2021-08-10T19:41:19+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project Makelangelo: Could not resolve dependencies for project com.marginallyclever:Makelangelo:jar:7.24.5: Failed to collect dependencies at net.sourceforge:kabeja:jar:0.4: Failed to read artifact descriptor for net.sourceforge:kabeja:jar:0.4: Could not transfer artifact net.sourceforge:kabeja:pom:0.4 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [openkm (http://maven.openkm.com, default, releases+snapshots)] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

Best regards