### PR TITLE
Fix Menu labels

### DIFF
--- a/src/main/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/com/marginallyclever/makelangelo/Makelangelo.java
@@ -208,7 +208,7 @@ public final class Makelangelo {
 	}
 
 	private JMenu createRobotMenu() {
-		JMenuItem bOpenControls = new JMenuItem(Translator.get("Open Controls"));
+		JMenuItem bOpenControls = new JMenuItem(Translator.get("OpenControls"));
 		bOpenControls.addActionListener((e)-> openPlotterControls());
 
 		JMenu menu = new JMenu(Translator.get("Robot"));

--- a/src/main/resources/languages/chinese.xml
+++ b/src/main/resources/languages/chinese.xml
@@ -591,6 +591,32 @@
 	</string>
 
 	<string>
+		<key>Robot</key>
+		<value>Makelangelo</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>OpenControls</key>
+		<value>Open Controls</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>SaveGCode</key>
+		<value>Save Gcode to file/SD</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Rewind</key>
+		<value>Rewind</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Play</key>
+		<value>Draw</value>
+		<hint>menu or dialog title</hint>
+	</string>
+
+	<string>
 		<key>SetHome</key>
 		<value>设置起始点</value>
 		<hint>manual driving dialog</hint>

--- a/src/main/resources/languages/dutch.xml
+++ b/src/main/resources/languages/dutch.xml
@@ -329,6 +329,32 @@
 	</string>
 
 	<string>
+		<key>Robot</key>
+		<value>Makelangelo</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>OpenControls</key>
+		<value>Open Controls</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>SaveGCode</key>
+		<value>Save Gcode to file/SD</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Rewind</key>
+		<value>Rewind</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Play</key>
+		<value>Draw</value>
+		<hint>menu or dialog title</hint>
+	</string>
+
+	<string>
 		<key>SetHome</key>
 		<value>Set home</value>
 		<hint>manual driving dialog</hint>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -549,6 +549,32 @@
 	</string>
 
 	<string>
+		<key>Robot</key>
+		<value>Makelangelo</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>OpenControls</key>
+		<value>Open Controls</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>SaveGCode</key>
+		<value>Save Gcode to file/SD</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Rewind</key>
+		<value>Rewind</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Play</key>
+		<value>Draw</value>
+		<hint>menu or dialog title</hint>
+	</string>
+
+	<string>
 		<key>SetHome</key>
 		<value>Set home</value>
 		<hint>manual driving dialog</hint>

--- a/src/main/resources/languages/german.xml
+++ b/src/main/resources/languages/german.xml
@@ -591,6 +591,32 @@
 	</string>
 
 	<string>
+		<key>Robot</key>
+		<value>Makelangelo</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>OpenControls</key>
+		<value>Kontrollen öffnen</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>SaveGCode</key>
+		<value>Gcode file/SD speichern</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Rewind</key>
+		<value>Zurückspulen</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Play</key>
+		<value>Zeichnen</value>
+		<hint>menu or dialog title</hint>
+	</string>
+
+	<string>
 		<key>SetHome</key>
 		<value>Home setzen</value>
 		<hint>manual driving dialog</hint>

--- a/src/main/resources/languages/piglatin.xml
+++ b/src/main/resources/languages/piglatin.xml
@@ -340,6 +340,32 @@
 	</string>
 
 	<string>
+		<key>Robot</key>
+		<value>Makelangelo</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>OpenControls</key>
+		<value>Open Controls</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>SaveGCode</key>
+		<value>Save Gcode to file/SD</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Rewind</key>
+		<value>Rewind</value>
+		<hint>menu or dialog title</hint>
+	</string>
+	<string>
+		<key>Play</key>
+		<value>Draw</value>
+		<hint>menu or dialog title</hint>
+	</string>
+
+	<string>
 		<key>SetHome</key>
 		<value>etSay omehay</value>
 		<hint>manual driving dialog</hint>


### PR DESCRIPTION
When compiling and using the new GUI for the first time i noticed missing Text Labels.
This is a quick fix for that. Added the Labels in English and German correctly (other languages are fallback english) 
