### PR TITLE
Remove PreferencesHelper & Translator in MakelangeloTest as they are not needed

### DIFF
--- a/src/test/com/marginallyclever/makelangelo/MakelangeloTest.java
+++ b/src/test/com/marginallyclever/makelangelo/MakelangeloTest.java
@@ -7,13 +7,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 public class MakelangeloTest {
     @Test
     public void checkVersion() throws IllegalStateException {
         Log.start();
-        PreferencesHelper.start();
-        Translator.start();
         String version = PropertiesFileHelper.getMakelangeloVersionPropertyValue();
         System.out.println("version " + version);
         String[] toks = version.split("\\.");


### PR DESCRIPTION
Hi,

here a small modification to enable MakelangeloTest to be run in the CI: PreferencesHelper and Translator are not needed ti read the version of the software

Regards