### PR TITLE
Fix LoadFilePanel panel frozzen after Open Cancelled.

### DIFF
--- a/src/main/com/marginallyclever/makelangelo/makeArt/io/LoadFilePanel.java
+++ b/src/main/com/marginallyclever/makelangelo/makeArt/io/LoadFilePanel.java
@@ -65,8 +65,9 @@ public class LoadFilePanel extends JPanel implements PreviewListener {
 	}
 	
 	public void chooseFile() {
-		mySubPanel.removeAll();
 		if (fc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+                        mySubPanel.removeAll();
+                    
 			String selectedFile = fc.getSelectedFile().getAbsolutePath();
 			Log.message("File selected by user: "+selectedFile);
 			filename.setText(selectedFile);


### PR DESCRIPTION
It seems to me that this permutation must be made. (unless it's normal ... or on purpose.)

Otherwise when you open a recent file and if you use the "Open" button which opens a JFileChooser that you "Cancel", the controls on the panel are no longer usable. 
(and as the image has not changed ... it's disagreeable to have to close the LoadFile dialog to reopen it ...)