### PR TITLE
Fix Language name value from preferences no match.

### DIFF
--- a/src/main/com/marginallyclever/makelangelo/Translator.java
+++ b/src/main/com/marginallyclever/makelangelo/Translator.java
@@ -66,7 +66,19 @@ public final class Translator {
 	static public boolean isThisTheFirstTimeLoadingLanguageFiles() {
 		// Did the language file disappear?  Offer the language dialog.
 		try {
-			if (doesLanguagePreferenceExist()) {
+			if (doesLanguagePreferenceExist()) {  
+
+                        // Does the language preference have a language name value 
+                        // that matches a language name value in an available language .xml file
+                        String languageNameFromPref = languagePreferenceNode.get(LANGUAGE_KEY, defaultLanguage);
+                        if ( ! languages.keySet().contains(languageNameFromPref)){
+                            Log.message("Translator::isThisTheFirstTimeLoadingLanguageFiles() Language Name \""+languageNameFromPref+"\" not available ...");
+                            
+                            // To avoid some null issues in Translator.get(String key),
+                            // lets say it's the first run (to ask the user to select a valid language name)
+                            return true;
+                        }
+                        
 				return false;
 			}
 		} catch (BackingStoreException e) {


### PR DESCRIPTION
To ask the user to select a valid language name if the preference language name does not match a language name value in the language file.

To avoid some null issues in Translator.get(String key)
or else you get this kind of problems :

```
Exception in thread "AWT-EventQueue-0" java.lang.ExceptionInInitializerError
...
Caused by: java.lang.NullPointerException: Cannot invoke "com.marginallyclever.makelangelo.TranslatorLanguage.get(String)" because the return value of "java.util.Map.get(Object)" is null
	at com.marginallyclever.makelangelo.Translator.get(Translator.java:223)
	at com.marginallyclever.makelangelo.makeArt.io.vector.LoadScratch3.<init>(LoadScratch3.java:68)
	at com.marginallyclever.makelangelo.makeArt.io.vector.TurtleFactory.<clinit>(TurtleFactory.java:13)

```