### PR TITLE
Move menubar to OS X menubar

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -98,6 +98,7 @@ public final class Makelangelo {
 	private Plotter myPlotter;
 	private Paper myPaper = new Paper();
 	private Turtle myTurtle = new Turtle();
+	private boolean isMacOS = false;
 
 	private TurtleRenderFacade myTurtleRenderer = new TurtleRenderFacade();
 	
@@ -115,6 +116,11 @@ public final class Makelangelo {
 	private DropTarget dropTarget;
 
 	public Makelangelo() {
+		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		if ((os.contains("mac")) || (os.contains("darwin"))) {
+			isMacOS = true;
+			System.setProperty("apple.laf.useScreenMenuBar", "true");
+		}
 		logger.debug("Locale={}", Locale.getDefault().toString());
 		logger.debug("Headless={}", (GraphicsEnvironment.isHeadless()?"Y":"N"));
 		logger.debug("Starting preferences...");
@@ -185,7 +191,7 @@ public final class Makelangelo {
 	 */
 	private void buildMenuBar() {
 		logger.debug("  adding menu bar...");
-		
+
 		mainMenuBar = new JMenuBar();
 		mainMenuBar.add(createFileMenu());
 		mainMenuBar.add(createPaperSettingsMenu());
@@ -237,7 +243,7 @@ public final class Makelangelo {
 				paperSettings.save();
 			}
 		});
-		
+
 		dialog.setVisible(true);
 	}
 
@@ -295,7 +301,7 @@ public final class Makelangelo {
 				plotterControls.closeConnection();
 			}
 		});
-		
+
 		dialog.setVisible(true);
 	}
 
@@ -379,7 +385,7 @@ public final class Makelangelo {
 		dialog.setLocationRelativeTo(mainFrame);
 		dialog.setMinimumSize(new Dimension(300,300));
 		dialog.pack();
-		
+
 
 		enableMenuBar(false);
 		dialog.addWindowListener(new WindowAdapter() {
@@ -390,7 +396,7 @@ public final class Makelangelo {
 				logger.debug(Translator.get("Finished"));
 			}
 		});
-		
+
 		dialog.setVisible(true);
 	}
 	
@@ -433,15 +439,16 @@ public final class Makelangelo {
 		buttonCheckForUpdate.addActionListener((e) -> checkForUpdate(false));
 		menu.add(buttonCheckForUpdate);
 
-		menu.addSeparator();
+		if (!isMacOS) {
+			menu.addSeparator();
 
-		JMenuItem buttonExit = new JMenuItem(Translator.get("MenuQuit"));
-		buttonExit.addActionListener((e) -> {
-			WindowEvent windowClosing = new WindowEvent(mainFrame, WindowEvent.WINDOW_CLOSING);
-			Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(windowClosing);
-		});
-		menu.add(buttonExit);
-
+			JMenuItem buttonExit = new JMenuItem(Translator.get("MenuQuit"));
+			buttonExit.addActionListener((e) -> {
+				WindowEvent windowClosing = new WindowEvent(mainFrame, WindowEvent.WINDOW_CLOSING);
+				Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(windowClosing);
+			});
+			menu.add(buttonExit);
+		}
 		return menu;
 	}
 
@@ -472,7 +479,7 @@ public final class Makelangelo {
 					recentFiles.addFilename(loader.getLastFileIn());
 				}
 			});
-			
+
 			dialog.setVisible(true);
 		} catch(Exception e) {
 			logger.error("Error while loading the file {}", filename, e);
@@ -494,7 +501,7 @@ public final class Makelangelo {
 				enableMenuBar(true);
 			}
 		});
-		
+
 		dialog.setVisible(true);
 	}
 
@@ -525,7 +532,7 @@ public final class Makelangelo {
 			GFXPreferences.setShowPenUp(b);
 		});
 		menu.add(checkboxShowPenUpMoves);
-		
+
 		return menu;
 	}
 
@@ -794,7 +801,7 @@ public final class Makelangelo {
 	public Turtle getTurtle() {
 		return myTurtle;
 	}
-	
+
 	public static void main(String[] args) {
 		Log.start();
 		// lazy init to be able to purge old files
@@ -809,7 +816,7 @@ public final class Makelangelo {
 		}
 		
 		setSystemLookAndFeel();
-		
+
 		javax.swing.SwingUtilities.invokeLater(()->{
 			Makelangelo makelangeloProgram = new Makelangelo();
 			makelangeloProgram.run();


### PR DESCRIPTION
On macos, the menubar can be integrated in the menubar on the top of the screen. 
Here is modification to make a better look and feel.
To move the menubar, an environment variable has only to be set. I also remove the quit menu item only for macos as it is already integrated in the "makelangelo" menu of macos.
Before: 
![image](https://user-images.githubusercontent.com/23615562/147405022-08420f44-19f5-486c-959e-6aa0e9b6bafc.png)

After:
![image](https://user-images.githubusercontent.com/23615562/147405030-bdae4841-eb76-4a1d-894b-ad4715a4a8dd.png)
