### PR TITLE
Upload the nightly build only on the main repos 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,13 +32,32 @@ jobs:
       run: ./mvnw -B clean package -DskipTests
 
     - name: Prepare package for release
-      if: github.ref == 'refs/heads/master'
+      if: github.repository == 'MarginallyClever/Makelangelo-software' && github.ref == 'refs/heads/master'
       run: mv ./target/Makelangelo-*-with-dependencies.jar ./target/to-upload.jar
 
-    # from https://github.com/marketplace/actions/deploy-nightly
+    - name: Upload artifact for release
+      if: github.repository == 'MarginallyClever/Makelangelo-software' && github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v2
+      with:
+        name: artifact
+        path: target/to-upload.jar
+        retention-days: 1
+
+  # from https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+  deploy-nightly:
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      if: github.repository == 'MarginallyClever/Makelangelo-software' && github.ref == 'refs/heads/master'
+      with:
+        name: artifact
+
+      # from https://github.com/marketplace/actions/deploy-nightly
     - name: Deploy universal release
       uses: WebFreak001/deploy-nightly@v1.1.0
-      if: github.ref == 'refs/heads/master'
+      if: github.repository == 'MarginallyClever/Makelangelo-software' && github.ref == 'refs/heads/master'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided by github actions
       with:
@@ -46,7 +65,7 @@ jobs:
         # in your browser and copy the full "upload_url" value including the {?name,label} part
         upload_url: https://uploads.github.com/repos/MarginallyClever/Makelangelo-software/releases/54908875/assets{?name,label}
         release_id: 54908875 # same as above (id can just be taken out the upload_url, it's used to find old releases)
-        asset_path: ./target/to-upload.jar # path to archive to upload
+        asset_path: to-upload.jar # path to archive to upload
         asset_name: makelangelo-nightly-$$.jar # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
         asset_content_type: application/zip # required by GitHub API
         max_releases: 3 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted


### PR DESCRIPTION
I also split the CI into 2 jobs for clarity

Here is the result:
![image](https://user-images.githubusercontent.com/23615562/148851880-b353d904-9222-4c08-b757-412c313bc6ff.png)
