### PR TITLE
Zoom on the machine at startup

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -705,7 +705,7 @@ public final class Makelangelo {
 		
 		mainFrame.setContentPane(createContentPane());
 
-		camera.zoomToFit(myPaper.getPaperWidth(),myPaper.getPaperHeight());
+		camera.zoomToFit(Paper.DEFAULT_WIDTH, Paper.DEFAULT_HEIGHT);
 		
 		logger.debug("  make visible...");
 		mainFrame.setVisible(true);

--- a/src/main/java/com/marginallyclever/makelangelo/paper/Paper.java
+++ b/src/main/java/com/marginallyclever/makelangelo/paper/Paper.java
@@ -12,10 +12,11 @@ import com.marginallyclever.makelangelo.preview.PreviewListener;
 import com.marginallyclever.util.PreferencesHelper;
 
 public class Paper implements PreviewListener {
-	private static final Logger logger = LoggerFactory.getLogger(Paper.class);
 
-	private static final int DEFAULT_WIDTH=420; // mm
-	private static final int DEFAULT_HEIGHT=594; // mm
+	public static final int DEFAULT_WIDTH = 420; // mm
+	public static final int DEFAULT_HEIGHT = 594; // mm
+
+	private static final Logger logger = LoggerFactory.getLogger(Paper.class);
 
 	private static final String PREF_KEY_ROTATION = "rotation";
 	private static final String PREF_KEY_PAPER_MARGIN = "paper_margin";


### PR DESCRIPTION
When selecting a small paper size and restarting the app, the viewport is zoomed on paper, and the user is confused.

Here is an example with A4.

Before:
![image](https://user-images.githubusercontent.com/23615562/149222612-0e6a589d-a319-458c-a233-72420e82679a.png)


After:
![image](https://user-images.githubusercontent.com/23615562/149222530-72b03795-445e-4287-8a72-732fffd00c91.png)
