### PR TITLE
Fix #446: the robot control window is not resizable anymore

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -356,6 +356,7 @@ public final class Makelangelo {
 			}
 		});
 
+		dialog.setResizable(false);
 		dialog.setVisible(true);
 	}
 

--- a/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/PlotterControls.java
+++ b/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/PlotterControls.java
@@ -259,6 +259,7 @@ public class PlotterControls extends JPanel {
 		frame.add(new PlotterControls(new Plotter(), new Turtle(), frame));
 		frame.pack();
 		frame.setVisible(true);
+		frame.setResizable(false);
 	}
 
 }


### PR DESCRIPTION
Fix the size of the windows to avoid the problem described in #446
> Also, show advanced controls, then drag window bottom downward. tabs to not resize to fill.