### PR TITLE
Traduction debug lost values due to not unique key (To start a discution about Traduction maintenance)

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
+++ b/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
@@ -121,7 +121,7 @@ public class TranslatorLanguage {
 
 				// store key/value pairs into a map
 				//logger.debug(language_file +"\t"+key+"\t=\t"+value);// KO language_file no in this scoop
-				logger.debug(src +"\t"+key+"\t=\t"+value);// OK
+				//logger.debug(src +"\t"+key+"\t=\t"+value);// OK
 				
 				if ( strings.containsKey(key)){
 				    // This sould not occure.

--- a/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
+++ b/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
@@ -1,25 +1,48 @@
 package com.marginallyclever.makelangelo;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.logging.Level;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 public class TranslatorLanguage {
 
 	private static final Logger logger = LoggerFactory.getLogger(TranslatorLanguage.class);
 	
+	private String src = "";// To be abble to have usefull information for debug (the url or path of the file where comms this traductions)
 	private String name = "";
 	private String author = "";
 	private Map<String, String> strings = new HashMap<String, String>();
@@ -29,6 +52,7 @@ public class TranslatorLanguage {
 	 * @param languageFile
 	 */
 	public void loadFromString(String languageFile) {
+	    this.src = languageFile;
 		final DocumentBuilder db = getDocumentBuilder();
 		if (db == null) {
 			return;
@@ -49,13 +73,29 @@ public class TranslatorLanguage {
 
 	/**
 	 * @param inputStream
+	 * @param src to be able to idetify the origine (url or file) of this traduction to help debug.
 	 */
-	public void loadFromInputStream(InputStream inputStream) {
+	public void loadFromInputStream(InputStream inputStream, String src) {
+		this.src = src;
 		final DocumentBuilder db = getDocumentBuilder();
 		if (db == null) {
 			return;
 		}
 		try {
+		    // TODO how do i specife the dtd path if in the jar ? as it s
+		    //https://stackoverflow.com/questions/8699620/how-to-validate-xml-with-dtd-using-java
+			db.setEntityResolver(new EntityResolver() {
+			@Override
+			public InputSource resolveEntity(String string, String string1) throws SAXException, IOException {
+			   logger.debug(String.format("TODO : resolveEntity (\"%s\",\"%s\");",string,string1));
+			     URL resource = getClass()./*getClassLoader().*/getResource("/languages/language_v0.dtd");
+			     logger.debug(String.format("TODO : %s",resource.toString()));
+			     Objects.requireNonNull(resource);
+			    return new InputSource(resource.toString());
+			    //throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+			}
+			});
+		    
 			Document dom = db.parse(inputStream);
 			load(dom);
 		} catch (SAXException | IOException e) {
@@ -66,29 +106,87 @@ public class TranslatorLanguage {
 	private void load(Document dom) {
 		final Element docEle = dom.getDocumentElement();
 
-		name = docEle.getElementsByTagName("name").item(0).getFirstChild().getNodeValue();
-		author = docEle.getElementsByTagName("author").item(0).getFirstChild().getNodeValue();
+		// PPAC37 : ??? so we have read the file (so it is normaly xml well formed. but it is not validated.) and as we do not use DTD or XSD the current kind of validation is non exception throw ( java.lang.NullPointerException )
+		name = docEle.getElementsByTagName(XML_TAG_NAME).item(0).getFirstChild().getNodeValue();
+		author = docEle.getElementsByTagName(XML_TAG_AUTHOR).item(0).getFirstChild().getNodeValue();
 
-		NodeList nl = docEle.getElementsByTagName("string");
+		NodeList nl = docEle.getElementsByTagName(XML_TAG_STRING);
 		if (nl != null && nl.getLength() > 0) {
 			for (int i = 0; i < nl.getLength(); i++) {
 
 				//get the element
 				Element el = (Element) nl.item(i);
-				String key = getTextValue(el, "key");
-				String value = getTextValue(el, "value");
+				String key = getTextValue(el, XML_TAG_KEY);
+				String value = getTextValue(el, XML_TAG_VALUE);
 
 				// store key/value pairs into a map
-				//logger.debug(language_file +"\t"+key+"\t=\t"+value);
+				//logger.debug(language_file +"\t"+key+"\t=\t"+value);// KO language_file no in this scoop
+				logger.debug(src +"\t"+key+"\t=\t"+value);// OK
+				
+				if ( strings.containsKey(key)){
+				    // This sould not occure.
+				    // TO REVIEW : this is due to the fact that the xml is manualy edited.
+				    // so ther is posibly multiple identical Key (that should be unique ).
+				//Key Unicity can be done with xml validation ... but this mean using the key as an id attribut 
+				//and adding a DTD to do .xml language DOCTYPE validation.
+				
+				// but in xml id value have some limitation (should be a NCName ... )
+				
+				    // ? ligne / pos in the file / stream ?
+				    
+				    if ( value.equals(strings.get(key))){
+					logger.debug(String.format("in %s SAME Key SAME value key:\"%s\" value:\"%s\"",src,key,value));
+				    }else{
+					logger.error(String.format("in %s SAME Key DIFF value key:\"%s\" value:\"%s\" oldvalue:\"%s\"",src,key,value,strings.get(key)));
+				    }
+				}
 				strings.put(key, value);
 			}
 		}
 	}
+	// PPAC37: To avoid confusion. (and maybe can be reused to generate .xml ...)
+	public static final String XML_TAG_NAME = "name";
+	public static final String XML_TAG_AUTHOR = "author";
+	//
+	public static final String XML_TAG_STRING = "string";
+	//
+	public static final String XML_TAG_KEY = "key";
+	public static final String XML_TAG_VALUE = "value";
+	public static final String XML_TAG_HINT = "hint";
+    
 
+	boolean xmlValidation = false; // so if a xml have no DTD this wil throw a lot of exceptions ...
+	
 	private DocumentBuilder getDocumentBuilder() {
 		DocumentBuilder db = null;
 		try {
-			db = buildDocumentBuilder().newDocumentBuilder();
+		    final DocumentBuilderFactory domFactory = buildDocumentBuilder();
+			if ( xmlValidation){
+			    domFactory.setValidating(true);
+			}
+		    
+			
+			db = domFactory.newDocumentBuilder();
+			   if (xmlValidation) {
+				db.setErrorHandler(new ErrorHandler() {
+				    @Override
+				    public void error(SAXParseException exception) throws SAXException {
+					// do something more useful in each of these handlers
+					exception.printStackTrace();
+				    }
+
+				    @Override
+				    public void fatalError(SAXParseException exception) throws SAXException {
+					exception.printStackTrace();
+				    }
+
+				    @Override
+				    public void warning(SAXParseException exception) throws SAXException {
+					exception.printStackTrace();
+				    }
+				});
+			}
+			
 		} catch (ParserConfigurationException e) {
 			logger.error("Failed to create a new document", e);
 		}
@@ -99,14 +197,96 @@ public class TranslatorLanguage {
 		return DocumentBuilderFactory.newInstance();
 	}
 
+	public SortedSet<String> missingKeys = new TreeSet<>();
+	
 	public String get(String key) {
 		if(strings.containsKey(key)) {
 			return strings.get(key);
 		} else {
+			// a sorted set of all the missing key to generat a essay .xml 
+			missingKeys.add(key);		    
 			return "Missing:"+key;
 		}
 	}
 
+	/**
+	 * https://examples.javacodegeeks.com/core-java/xml/parsers/documentbuilderfactory/create-xml-file-in-java-using-dom-parser-example/
+	 *
+	 * https://mkyong.com/java/how-to-create-xml-file-in-java-dom/
+	 *
+	 */
+	public void generatePartialXmlFileWithMissingKey() {
+	    try {
+		//FileWriter fw = new FileWriter("missing_language.xml");
+		Iterator<String> it = missingKeys.iterator();
+		DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
+		Document doc = documentBuilder.newDocument();
+		// root element
+		Element root = doc.createElement("language");
+		final long currentTimeMillis = System.currentTimeMillis();
+		Date dateGenerated = new Date(currentTimeMillis);
+		     root.setAttribute("timestamp", ""+currentTimeMillis);
+		     SimpleDateFormat sdf = new SimpleDateFormat();
+		     root.setAttribute("date", sdf.format(dateGenerated));
+		     
+		doc.appendChild(root);
+		
+		Element elemMeta = doc.createElement("meta");
+		root.appendChild(elemMeta);
+		
+		Element elemLanguageName = doc.createElement(XML_TAG_NAME);
+		elemMeta.appendChild(elemLanguageName);
+		elemLanguageName.setTextContent(name+"_");
+		
+		Element elemAuthor = doc.createElement(XML_TAG_AUTHOR);
+		elemMeta.appendChild(elemAuthor);
+		elemAuthor.setTextContent(author);
+		
+		// add xml comment
+		Comment comment = doc.createComment("for special characters like < &, need CDATA");
+		elemMeta.appendChild(comment);
+		while (it.hasNext()) {
+		    String k = it.next();
+		    //
+		    Element elemString = doc.createElement(XML_TAG_STRING);
+		    Element elemKey = doc.createElement(XML_TAG_KEY);
+		    elemKey.appendChild(doc.createTextNode(k));
+		    Element elemValue = doc.createElement(XML_TAG_VALUE);
+    //		     // add xml CDATA
+    //		    CDATASection cdataSection = doc.createCDATASection("HTML tag <code>testing</code>");
+    //		    elemValue.appendChild(cdataSection);
+		    elemValue.appendChild(doc.createTextNode("todo:" + k));
+		    //
+		    Element elemHint = doc.createElement(XML_TAG_HINT);
+		    elemHint.appendChild(doc.createTextNode("todo"));
+		    elemString.appendChild(elemKey);
+		    elemString.appendChild(elemValue);
+		    elemString.appendChild(elemHint);
+		    root.appendChild(elemString);
+		}
+		// create the xml file
+		//transform the DOM Object to an XML File
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+		Transformer transformer = transformerFactory.newTransformer();
+		// pretty print XML
+		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+		DOMSource domSource = new DOMSource(doc);
+		String xmlFilePath = "missing_language.xml";
+		final File file = new File(xmlFilePath);
+		StreamResult streamResult = new StreamResult(file);
+		// If you use
+		// StreamResult result = new StreamResult(System.out);
+		// the output will be pushed to the standard output ...
+		// You can use that for debugging 
+		transformer.transform(domSource, streamResult);
+		System.out.println("Done creating XML File: " + file.getAbsolutePath());
+	    } catch (TransformerException ex) {
+		java.util.logging.Logger.getLogger(TranslatorLanguage.class.getName()).log(Level.SEVERE, null, ex);
+	    } catch (ParserConfigurationException ex) {
+		java.util.logging.Logger.getLogger(TranslatorLanguage.class.getName()).log(Level.SEVERE, null, ex);
+	    }
+	}
 
 	/**
 	 * <p>
@@ -132,6 +312,14 @@ public class TranslatorLanguage {
 		if (nl != null && nl.getLength() > 0) {
 			Element el = (Element) nl.item(0);
 			textVal = el.getFirstChild().getNodeValue();
+			if ( nl.getLength()>1){
+			    // This could be avoid if we validate the .xml to verify it befor commiting it or when building the projet.
+			    logger.debug(String.format("in %s Using FirstChild found but have other ... %s value %s",src,tagName,textVal));
+			    for ( int i =1 ; i<nl.getLength() ; i++){
+				logger.debug(String.format("Ignored ... value %s",nl.item(i).getFirstChild().getNodeValue()));
+				
+			    }
+			}
 		}
 		textVal = textVal.replace("\\n", "\n");
 		return textVal;

--- a/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
+++ b/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
@@ -197,19 +197,24 @@ public class TranslatorLanguage {
 		return DocumentBuilderFactory.newInstance();
 	}
 
+	/**
+	 * To have a way to remember missing key asked ... to later create a partial missing key .xml file.
+	 */
 	public SortedSet<String> missingKeys = new TreeSet<>();
 	
 	public String get(String key) {
 		if(strings.containsKey(key)) {
 			return strings.get(key);
 		} else {
-			// a sorted set of all the missing key to generat a essay .xml 
+			// a sorted set of all the missing key to eventualy later generat a partial language .xml 
 			missingKeys.add(key);		    
 			return "Missing:"+key;
 		}
 	}
 
 	/**
+	 * PPAC37 : TODO to help adding missing key ...
+	 * 
 	 * https://examples.javacodegeeks.com/core-java/xml/parsers/documentbuilderfactory/create-xml-file-in-java-using-dom-parser-example/
 	 *
 	 * https://mkyong.com/java/how-to-create-xml-file-in-java-dom/
@@ -237,7 +242,7 @@ public class TranslatorLanguage {
 		
 		Element elemLanguageName = doc.createElement(XML_TAG_NAME);
 		elemMeta.appendChild(elemLanguageName);
-		elemLanguageName.setTextContent(name+"_");
+		elemLanguageName.setTextContent(name+"_");// The "_" at the end is to avoid having the same language name. (or this will replace all traduction ... when loaded)
 		
 		Element elemAuthor = doc.createElement(XML_TAG_AUTHOR);
 		elemMeta.appendChild(elemAuthor);

--- a/src/main/resources/languages/german.xml
+++ b/src/main/resources/languages/german.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE language>
+<!DOCTYPE language SYSTEM "language_v0.dtd"><!-- ADDED BY PPAC37 : SYSTEM "language_v0.dtd"-->
 <language>
 	<meta>
 		<name>Deutsch</name>

--- a/src/main/resources/languages/language_v0.dtd
+++ b/src/main/resources/languages/language_v0.dtd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2022 Marginally Clever Robots, Limited.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+-->
+
+<!-- 
+    TODO define vocabulary identification data //PPAC37 : i begin with DTD, dont know what to use here.
+    PUBLIC ID  : -//vendor//vocabulary//EN
+    SYSTEM ID  : http://server/path/__NAME__
+-->
+
+
+<!-- DTD definition so we can xml validate ( vocabulary/syntax ) a xml file 
+by adding in this header : <!DOCTYPE language SYSTEM "language_v0.dtd">
+or ( not to be depanding of an external file )
+<!DOCTYPE language [<<< The DTD definition that folow >>>]>
+-->
+<!ELEMENT language (meta,string+)>
+
+<!ELEMENT meta (name,author)>
+
+<!ELEMENT name (#PCDATA)>
+<!ELEMENT author (#PCDATA)>
+
+<!ELEMENT string (key,value,hint?)><!-- remove the ? at the and of "hint?" to have validation issue for the <string> that do not containe a <hint>  -->
+
+<!ATTLIST string id ID #IMPLIED><!-- PPAC37: not currently use but could be a way to enforce key unicity -->
+<!ELEMENT key (#PCDATA)> <!-- 
+// TODO to reveiw for key unicity, migrate the elements as and attribut id of the <strnig> elements
+<!ELEMENT string (value,hint?)>
+<!ATTLIST string id ID #REQUIRED> 
+// but have to change the read/write implementation as an element becom an attribut .
+TODO study case code change / xml rework / implication (no back compatibility )
+  -->				
+<!ELEMENT value (#PCDATA)>
+<!ELEMENT hint (#PCDATA)>

--- a/src/main/resources/languages/language_v0.xsd
+++ b/src/main/resources/languages/language_v0.xsd
@@ -1,0 +1,25 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="language">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="meta">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="name"/>
+              <xs:element type="xs:string" name="author"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="string" maxOccurs="unbounded" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="key"/>
+              <xs:element type="xs:string" name="value"/>
+              <xs:element type="xs:string" name="hint" minOccurs="0"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/main/resources/languages/language_v0_To_properties.xsl
+++ b/src/main/resources/languages/language_v0_To_properties.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : language_v0_To_properties.xsl
+    Created on : 14 janvier 2022, 16:31
+    Author     : q6
+    Description:
+        A try to generate a .properties file from a .xml DTD language ( juste so i can use the lang .properties edit under Netbeans ...  )
+        
+        BUG : multiline CDATA converte  ( normaly a value sould be on a single ligne , but, int CDATA you may have multiple line ... ? \n replacement ??? )
+        
+        A way to automaticaly rename output file ( MakelangeloLanguage_codeLang_CodeCountry.properties )
+        // ? only in the invocation of the convertion ( cf have to do this in a specific .java class ? or in the arguments used to do the transformation ) 
+        
+        
+        As xml engine ( can have diffrent implementation/comportement like xalan vs .NETxmlEmbed vs ... ) this may not work ...
+        https://stackoverflow.com/questions/723226/producing-a-new-line-in-xslt
+        (TODO : Im using NetBeans 12.6 xml commands via toolsbar icons (so i even dont actualy know what xml engine i use ... )
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:output method="text"/>
+    <xsl:template match="/">        
+        <xsl:text># Fichier auto généré le ??? d'aprés ???</xsl:text>
+        <xsl:text>&#xd;&#xa;</xsl:text><!--Add a \r\n (as "&#xd;" is normaly a carriage return) and ( "&#xa;" is normaly a line feed / new line  ) -->
+            
+        <xsl:text># </xsl:text>
+        <xsl:value-of select="//language/meta/name"/>
+        <xsl:text>&#xd;&#xa;</xsl:text><!--Add a \r\n (as "&#xd;" is normaly a carriage return) and ( "&#xa;" is normaly a line feed / new line  ) -->
+            
+        <xsl:text># </xsl:text>
+        <xsl:value-of select="//language/meta/author"/>
+        <xsl:for-each select="//language/string">
+            <xsl:text>&#xd;&#xa;</xsl:text><!--Add a \r\n (as "&#xd;" is normaly a carriage return) and ( "&#xa;" is normaly a line feed / new line  ) -->
+            
+            <xsl:text># </xsl:text>
+            <xsl:value-of select="hint" />
+            <xsl:text>&#xd;&#xa;</xsl:text><!--Add a \r\n (as "&#xd;" is normaly a carriage return) and ( "&#xa;" is normaly a line feed / new line  ) -->
+            <xsl:value-of select="key" />=<xsl:value-of select="value" />
+        </xsl:for-each>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/languages/language_v0_To_v1.xsl
+++ b/src/main/resources/languages/language_v0_To_v1.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+https://analyse-innovation-solution.fr/publication/fr/xslt/tutoriel-xslt-bases
+
+    Document   : language_v0_To_v1.xsl
+    Created on : 14 janvier 2022, 16:31
+    Author     : q6
+    Description:
+        A try to transforme a language .xml DTD language v0 file to a language .xml file DTD language v1 ( using the key in an ID to get xml validation unique key vérification)
+        BUG ? should embed the DTD to validate in stand alone ...
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
+    <xsl:output method="xml" indent="yes"  encoding="utf-8" omit-xml-declaration="no" />
+    <!-- 
+<xsl:include href="functions_urls.xslt" />
+TODO customize transformation rules 
+         syntax recommendation http://www.w3.org/TR/xslt 
+        
+         https://stackoverflow.com/questions/1575111/can-an-xslt-insert-the-current-date
+         https://www.oreilly.com/library/view/xslt-2nd-edition/9780596527211/re67.html
+         
+          <xsl:value-of 
+      select="format-date(current-date(), 
+              '[FNn], the [D1o] of [MNn], [Y01]')"/>
+         
+         SSI XSTLv2.0 ? <xsl:value-of  select="current-dateTime()"/> 
+         
+         xsl:stylesheet  xmlns:java="java" , <xsl:value-of select="java:util.Date.new()"/> + secure processing feature is set to false ?
+    -->
+    <xsl:template match="/">        
+        <xsl:comment>Fichier auto généré le ??? (todo find the way to add a date/timestamp ... only posible if ... v2.0 or ? xml engine ?)
+           
+            d'aprés (todo find a way to insert the origine base file used ... if posible )</xsl:comment>        
+        <language>
+            <xsl:copy-of select="//language/meta"></xsl:copy-of>
+            <xsl:for-each select="//language/string">                
+                <xsl:variable name="key_for_id" select="key" />
+                <string>
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="$key_for_id" />
+                    </xsl:attribute>    
+                    <!--
+                    <key><xsl:value-of select="$key_for_id" /></key>                         
+                    <value><xsl:value-of select="value" /></value>         
+                    <hint><xsl:value-of select="hint" /></hint>
+                    -->                    
+                    <xsl:copy-of select="*" /><!-- ? disable-output-escaping="yes"  -->                    
+                </string>
+            </xsl:for-each>
+        </language>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/languages/language_v0_To_v1.xsl
+++ b/src/main/resources/languages/language_v0_To_v1.xsl
@@ -1,46 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-https://analyse-innovation-solution.fr/publication/fr/xslt/tutoriel-xslt-bases
-
     Document   : language_v0_To_v1.xsl
     Created on : 14 janvier 2022, 16:31
-    Author     : q6
+    Author     : PPAC37
     Description:
-        A try to transforme a language .xml DTD language v0 file to a language .xml file DTD language v1 ( using the key in an ID to get xml validation unique key vérification)
-        BUG ? should embed the DTD to validate in stand alone ...
+        A try to transforme a language .xml DTD language "v0" file 
+        to a language .xml file DTD language "v1" 
+        ( using the key in an ID to get xml validation unique key vérification)        
         
-        https://stackoverflow.com/questions/42047263/add-a-doctype-declaration-on-xsl-ouptut
+        BUG : converte CDATA contente.
+        
+        TODO : insert a timestamp ( ? an argument ? xml version / engine ... )
+            https://stackoverflow.com/questions/1575111/can-an-xslt-insert-the-current-date
+            https://www.oreilly.com/library/view/xslt-2nd-edition/9780596527211/re67.html
+             
+         
+            SSI XSLTv2.0 ? 
+                <xsl:value-of  select="current-dateTime()"/> 
+                <xsl:value-of select="format-date(current-date(), '[FNn], the [D1o] of [MNn], [Y01]')"/>
+            
+            if in XSLTv1.0 :
+                xsl:stylesheet  xmlns:java="java" , <xsl:value-of select="java:util.Date.new()"/> 
+                But ??? secure processing feature is set to false ?
+         
+        
+        TODO : insert a posible src filename/path. ( an argument ? )
+        
+        DONE : https://stackoverflow.com/questions/42047263/add-a-doctype-declaration-on-xsl-ouptut
+        DONE but to reveiw (TODO as a fonction) : https://stackoverflow.com/questions/723226/producing-a-new-line-in-xslt
+        
+        Documentation :
+        (fr) https://analyse-innovation-solution.fr/publication/fr/xslt/tutoriel-xslt-bases
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
     <xsl:output method="xml" indent="yes"  encoding="utf-8" omit-xml-declaration="no" 
                 standalone="no" doctype-system="language_v0.dtd" 
     />
-    <!-- 
-<xsl:include href="functions_urls.xslt" />
-TODO customize transformation rules 
-         syntax recommendation http://www.w3.org/TR/xslt 
-        
-         https://stackoverflow.com/questions/1575111/can-an-xslt-insert-the-current-date
-         https://www.oreilly.com/library/view/xslt-2nd-edition/9780596527211/re67.html
-         
-          <xsl:value-of 
-      select="format-date(current-date(), 
-              '[FNn], the [D1o] of [MNn], [Y01]')"/>
-         
-         SSI XSTLv2.0 ? <xsl:value-of  select="current-dateTime()"/> 
-         
-         xsl:stylesheet  xmlns:java="java" , <xsl:value-of select="java:util.Date.new()"/> + secure processing feature is set to false ?
+    <!-- DONE : customize transformation rules 
+         TODO : syntax recommendation http://www.w3.org/TR/xslt 
     -->
     <xsl:template match="/">        
-        <xsl:comment>Fichier auto généré le ??? (todo find the way to add a date/timestamp ... only posible if ... v2.0 or ? xml engine ?)
-           
-            d'aprés (todo find a way to insert the origine base file used ... if posible )</xsl:comment>   
-        <xsl:text>
-        </xsl:text>
+        <xsl:comment>Auto-generated file the ? (TODO add date/timestamp) from (TODO find a way to insert the name/path of the original file used...)</xsl:comment>   
+        <xsl:text>&#xd;&#xa;</xsl:text><!--Add a \r\n (as "&#xd;" is normaly a carriage return) and ( "&#xa;" is normaly a line feed / new line  ) -->        
+        <xsl:comment>WARNING: modifications will be lost during the next generation.</xsl:comment>   
+        <xsl:text>&#xd;&#xa;</xsl:text>
         <language>
-            <xsl:copy-of select="//language/meta"></xsl:copy-of>
+            <!--<xsl:copy-of select="//language/meta"></xsl:copy-of>-->        
+            <meta>
+                <name>
+                    <xsl:value-of select="//language/meta/name" />
+                    <xsl:text>_v1</xsl:text><!-- Altering the language name to avoid confusion and possible lost/overwriting of an existing on the application startup-->
+                </name>                         
+                <author>
+                    <xsl:value-of select="//language/meta/author" />
+                </author>      
+            </meta>
+             
             <xsl:for-each select="//language/string">                
                 <xsl:variable name="key_for_id" select="key" />
                 <string>
@@ -58,3 +75,4 @@ TODO customize transformation rules
         </language>
     </xsl:template>
 </xsl:stylesheet>
+

--- a/src/main/resources/languages/language_v0_To_v1.xsl
+++ b/src/main/resources/languages/language_v0_To_v1.xsl
@@ -9,10 +9,14 @@ https://analyse-innovation-solution.fr/publication/fr/xslt/tutoriel-xslt-bases
     Description:
         A try to transforme a language .xml DTD language v0 file to a language .xml file DTD language v1 ( using the key in an ID to get xml validation unique key vérification)
         BUG ? should embed the DTD to validate in stand alone ...
+        
+        https://stackoverflow.com/questions/42047263/add-a-doctype-declaration-on-xsl-ouptut
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" >
-    <xsl:output method="xml" indent="yes"  encoding="utf-8" omit-xml-declaration="no" />
+    <xsl:output method="xml" indent="yes"  encoding="utf-8" omit-xml-declaration="no" 
+                standalone="no" doctype-system="language_v0.dtd" 
+    />
     <!-- 
 <xsl:include href="functions_urls.xslt" />
 TODO customize transformation rules 
@@ -32,7 +36,9 @@ TODO customize transformation rules
     <xsl:template match="/">        
         <xsl:comment>Fichier auto généré le ??? (todo find the way to add a date/timestamp ... only posible if ... v2.0 or ? xml engine ?)
            
-            d'aprés (todo find a way to insert the origine base file used ... if posible )</xsl:comment>        
+            d'aprés (todo find a way to insert the origine base file used ... if posible )</xsl:comment>   
+        <xsl:text>
+        </xsl:text>
         <language>
             <xsl:copy-of select="//language/meta"></xsl:copy-of>
             <xsl:for-each select="//language/string">                


### PR DESCRIPTION
Hello !
Things to review in the translations.
Both in code and .xml files
Currently some translation values ​​are lost because

there are several times the same translation key in the .xml files
ex:
```<key>...</key>```
* Left
* Right
* MenuSaveFile
* spraypaintToolTest
* MenuResetMachinePreferences
* Menu Log
* PaperSize
* voronoiStipplingCellCount
* voronoiStipplingDotMin
* NotConnected
* FileTypeImage
* Open

 or because there is more than one translation ```<value>``` (the current code only use the first found) for a ```<key>```
https://github.com/MarginallyClever/Makelangelo-software/blob/03e9f11afac3e7badf82b8851d435d81fc305c14/src/main/resources/languages/german.xml#L1059-L1063

There is also the question of maintaining the .xml translation files when changing the value of a key.

A list of the keys (when renaming a key) of the translation files should be kept up to date.
This would make it easier to maintain the other translation files. (to update a new translation file created on an old version ...)

example in 
https://github.com/MarginallyClever/Makelangelo-software/commit/9463279394b671ae0b3d9475f9678d283c026fac
```
<key>PaperWidth</key> -> <key>PaperSettings.PaperSize</key>
<key>PaperHeight</key> -> <key>PaperSettings.PaperHeight</key>
<key>OpenControls</key> -> <key>RobotMenu.OpenControls</key>
<key>SaveGCode</key> -> <key>RobotMenu.SaveGCode</key>
```
But the other translation files seems not have been modified/impacted...