### PR TITLE
InfillTurtleAction fix to update the preview sliver last max limite

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/InfillTurtleAction.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/InfillTurtleAction.java
@@ -27,6 +27,8 @@ public class InfillTurtleAction extends AbstractAction {
 		Turtle t = myMakelangelo.getTurtle();
 		try {
 			t.add(infill.run(t));
+			// PPAC : to indirectly update the slider last max limit (or else max limit is not updated and no view update on infill menu item clic)
+			myMakelangelo.setTurtle(t);
 		} catch (Exception ex) {
 			logger.error("Failed to infill", ex);
 		}


### PR DESCRIPTION
to view the possible infil created ...

As in InfillTurtelAction, myMakelangelo.setTurtle indirectly call myTurtleRenderer.setTurtle(turtle); :
https://github.com/MarginallyClever/Makelangelo-software/blob/94745b3e8154a335e397d5a0c5091d6e1e6d78b6/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java#L974-L976

and so the last slider position is updated. ( setLast(size);  line 95 )
https://github.com/MarginallyClever/Makelangelo-software/blob/94745b3e8154a335e397d5a0c5091d6e1e6d78b6/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFacade.java#L89-L96
