### PR TITLE
👷 Update github actions/setup-java to v2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,19 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: 17
-
-    # from https://github.com/marketplace/actions/cache
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
 
     # from https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
     - name: Build and Test with Maven


### PR DESCRIPTION
v2 has been published april 2021, here is the doc: https://github.com/actions/setup-java
Major changes: need to specify the type of jvm and the maven cache can be directly configured