### PR TITLE
👷 Github actions now build only master on the main repo and PR from contributors

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,8 @@ name: Java CI with Maven
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
I noticed in the PR https://github.com/MarginallyClever/Makelangelo-software/pull/481 that the CI ran 2 times on different triggers: 
![image](https://user-images.githubusercontent.com/23615562/151515453-96db162a-604d-4a88-b70d-c6403d341a4b.png)

So now, when creating a new branch, either open a pull request to have the CI running or add it to this file if it is a long lived branch like `bugfix-7.31.x`.
