### PR TITLE
💄 use java.awt.Desktop to enhance the user experience on mac os

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -654,15 +654,19 @@ public final class Makelangelo {
 			}
 		});
 		menu.add(buttonForums);
-		
-		JMenuItem buttonAbout = new JMenuItem(Translator.get("MenuAbout"));
-		buttonAbout.addActionListener((e) -> {
-			DialogAbout a = new DialogAbout();
-			a.display(mainFrame,VERSION);
-		});
-		menu.add(buttonAbout);
+
+		if (!isMacOS) {
+			JMenuItem buttonAbout = new JMenuItem(Translator.get("MenuAbout"));
+			buttonAbout.addActionListener((e) -> onDialogButton());
+			menu.add(buttonAbout);
+		}
 
 		return menu;
+	}
+
+	private void onDialogButton() {
+		DialogAbout a = new DialogAbout();
+		a.display(mainFrame,VERSION);
 	}
 
 	private void runLogPanel() {
@@ -812,6 +816,18 @@ public final class Makelangelo {
 		setWindowSizeAndPosition();
 
 		setupDropTarget();
+
+		if (Desktop.isDesktopSupported()) {
+			Desktop desktop = Desktop.getDesktop();
+			desktop.setQuitHandler((evt, res) -> {
+				if (onClosing()) {
+					res.performQuit();
+				} else {
+					res.cancelQuit();
+				}
+			});
+			desktop.setAboutHandler((e) -> onDialogButton());
+		}
 	}
 	
 	private void setupDropTarget() {
@@ -908,7 +924,7 @@ public final class Makelangelo {
 		});
 	}
 
-	private void onClosing() {
+	private boolean onClosing() {
 		int result = JOptionPane.showConfirmDialog(mainFrame, Translator.get("ConfirmQuitQuestion"),
 				Translator.get("ConfirmQuitTitle"), JOptionPane.YES_NO_OPTION);
 		if (result == JOptionPane.YES_OPTION) {
@@ -928,7 +944,9 @@ public final class Makelangelo {
 				previewPanel.stop();
 				mainFrame.dispose();
 			}).start();
+			return true;
 		}
+		return false;
 	}
 	
 	private static final String PREFERENCE_SAVE_PATH = "savePath";


### PR DESCRIPTION
Until now, the native menu Makelangelo on macos was not bonded to the app. When clicking on the "about", it will not show the about of Makelangelo but one built in the jvm. 
![image](https://user-images.githubusercontent.com/23615562/151708722-ec97e68f-9983-40bc-b9ba-5eaa77ce9825.png)

When quitting the app from the same menu, the confirmation was not displayed. Only when closing the window with the red button is the left corner triggers it.

It uses the [java.awt.Desktop API](https://docs.oracle.com/javase/9/docs/api/java/awt/Desktop.html) introduced in java 6 to make it works.

Here is what looks like the dialog box on the built in menu: 
![image](https://user-images.githubusercontent.com/23615562/151708981-0c24fef0-38b9-43e5-a58a-b845e8b3a73e.png)
