### PR TITLE
New gui translated elements

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -341,7 +341,7 @@ public final class Makelangelo {
 				.forEach(iter -> {
 					TurtleRenderer renderer = iter.getTurtleRenderer();
 					String name = iter.getName();					
-					JRadioButtonMenuItem button = new JRadioButtonMenuItem(iter.getTranslatedText());
+					JRadioButtonMenuItem button = new JRadioButtonMenuItem(Translator.get("TurtleRenderFactory."+iter.toString()));
 					if (myTurtleRenderer.getRenderer() == renderer) button.setSelected(true);
 					button.addActionListener((e)-> onTurtleRenderChange(name));
 					menu.add(button);

--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -341,7 +341,7 @@ public final class Makelangelo {
 				.forEach(iter -> {
 					TurtleRenderer renderer = iter.getTurtleRenderer();
 					String name = iter.getName();					
-					JRadioButtonMenuItem button = new JRadioButtonMenuItem(iter.getTraductedText());
+					JRadioButtonMenuItem button = new JRadioButtonMenuItem(iter.getTranslatedText());
 					if (myTurtleRenderer.getRenderer() == renderer) button.setSelected(true);
 					button.addActionListener((e)-> onTurtleRenderChange(name));
 					menu.add(button);

--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -340,8 +340,8 @@ public final class Makelangelo {
 		Arrays.stream(TurtleRenderFactory.values())
 				.forEach(iter -> {
 					TurtleRenderer renderer = iter.getTurtleRenderer();
-					String name = iter.getName();
-					JRadioButtonMenuItem button = new JRadioButtonMenuItem(name);
+					String name = iter.getName();					
+					JRadioButtonMenuItem button = new JRadioButtonMenuItem(iter.getTraductedText());
 					if (myTurtleRenderer.getRenderer() == renderer) button.setSelected(true);
 					button.addActionListener((e)-> onTurtleRenderChange(name));
 					menu.add(button);

--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -275,7 +275,7 @@ public final class Makelangelo {
 
 	private void openPlotterSettings() {
 		PlotterSettingsPanel settings = new PlotterSettingsPanel(myPlotter);
-		JDialog dialog = new JDialog(mainFrame,PlotterSettingsPanel.class.getSimpleName());
+		JDialog dialog = new JDialog(mainFrame,Translator.get("PlotterSettingsPanel.Title"));
 		dialog.add(settings);
 		dialog.setLocationRelativeTo(mainFrame);
 		dialog.setMinimumSize(new Dimension(300,300));

--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -294,7 +294,7 @@ public final class Makelangelo {
 
 	private void openPaperSettings() {
 		PaperSettings settings = new PaperSettings(myPaper);
-		JDialog dialog = new JDialog(mainFrame,PaperSettings.class.getSimpleName());
+		JDialog dialog = new JDialog(mainFrame,Translator.get("PaperSettings.Title"));
 		dialog.add(settings);
 		dialog.setLocationRelativeTo(mainFrame);
 		dialog.setMinimumSize(new Dimension(300,300));

--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -341,7 +341,7 @@ public final class Makelangelo {
 				.forEach(iter -> {
 					TurtleRenderer renderer = iter.getTurtleRenderer();
 					String name = iter.getName();					
-					JRadioButtonMenuItem button = new JRadioButtonMenuItem(Translator.get("TurtleRenderFactory."+iter.toString()));
+					JRadioButtonMenuItem button = new JRadioButtonMenuItem(iter.getTranslatedText());
 					if (myTurtleRenderer.getRenderer() == renderer) button.setSelected(true);
 					button.addActionListener((e)-> onTurtleRenderChange(name));
 					menu.add(button);

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Dragon_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Dragon_Panel.java
@@ -24,7 +24,7 @@ public class Generator_Dragon_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 
 		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),16,0,Generator_Dragon.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Dragon_curve'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Dragon_curve'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_FibonacciSpiral_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_FibonacciSpiral_Panel.java
@@ -24,7 +24,7 @@ public class Generator_FibonacciSpiral_Panel extends TurtleGeneratorPanel {
 		this.generator = generator_FibonacciSpiral;
 		
 		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),16,0,Generator_Dragon.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Fibonacci_number'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Fibonacci_number'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
@@ -24,8 +24,10 @@ public class Generator_GosperCurve_Panel extends TurtleGeneratorPanel {
 		
 		this.generator = generator;
 
-		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),6,1,Generator_GosperCurve.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Hilbert_curve'>Learn more</a>"));
+		add(fieldOrder = new SelectSlider("order",
+				Translator.get("HilbertCurveOrder")// As this is the same concept and traduction value but this traduction key is confusing as we are in GosperCurve_Panle ...
+				,6,1,Generator_GosperCurve.getOrder()));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Gosper_curve'>Learn more</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
@@ -25,7 +25,7 @@ public class Generator_GosperCurve_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 
 		add(fieldOrder = new SelectSlider("order",
-				Translator.get("HilbertCurveOrder")// As this is the same concept and traduction value but this traduction key is confusing as we are in GosperCurve_Panle ...
+				Translator.get("HilbertCurveOrder")// As this is the same concept and translation value but this translation key is confusing as we are in GosperCurve_Panle ...
 				,6,1,Generator_GosperCurve.getOrder()));
 		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Gosper_curve'>Learn more</a>"));
 	}

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_GosperCurve_Panel.java
@@ -27,7 +27,7 @@ public class Generator_GosperCurve_Panel extends TurtleGeneratorPanel {
 		add(fieldOrder = new SelectSlider("order",
 				Translator.get("HilbertCurveOrder")// As this is the same concept and translation value but this translation key is confusing as we are in GosperCurve_Panle ...
 				,6,1,Generator_GosperCurve.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Gosper_curve'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Gosper_curve'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_HilbertCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_HilbertCurve_Panel.java
@@ -25,7 +25,7 @@ public class Generator_HilbertCurve_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 
 		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),8,1,Generator_HilbertCurve.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Hilbert_curve'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Hilbert_curve'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_HilbertCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_HilbertCurve_Panel.java
@@ -3,6 +3,7 @@ package com.marginallyclever.makelangelo.makeArt.turtleGenerator;
 import java.beans.PropertyChangeEvent;
 
 import com.marginallyclever.makelangelo.Translator;
+import com.marginallyclever.makelangelo.select.SelectReadOnlyText;
 import com.marginallyclever.makelangelo.select.SelectSlider;
 
 /**
@@ -24,6 +25,7 @@ public class Generator_HilbertCurve_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 
 		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),8,1,Generator_HilbertCurve.getOrder()));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Hilbert_curve'>Learn more</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_KochCurve_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_KochCurve_Panel.java
@@ -25,7 +25,7 @@ public class Generator_KochCurve_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 
 		add(fieldOrder = new SelectSlider("order",Translator.get("HilbertCurveOrder"),7,1,Generator_HilbertCurve.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Koch_curve'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Koch_curve'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_LSystemTree_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_LSystemTree_Panel.java
@@ -33,7 +33,7 @@ public class Generator_LSystemTree_Panel extends TurtleGeneratorPanel {
 		add(field_orderScale = new SelectSlider("scale",Translator.get("LSystemOrderScale"),100,1,(int)(generator.getScale()*100)));
 		add(field_angle      = new SelectSlider("angle",Translator.get("LSystemAngle"),360,1,(int)generator.getAngle()));
 		add(field_noise      = new SelectSlider("noise",Translator.get("LSystemNoise"),100,0,(int)generator.getNoise()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/L-system'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/L-system'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Lissajous_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Lissajous_Panel.java
@@ -30,7 +30,7 @@ public class Generator_Lissajous_Panel extends TurtleGeneratorPanel {
 		add(field_b = new SelectSlider("b",Translator.get("LissajousB"),100,1,Generator_Lissajous.getB()));
 		add(field_delta = new SelectSlider("delta",Translator.get("LissajousDelta"),1000,0,(int)(Generator_Lissajous.getDelta()*1000.0)));
 		add(field_numSamples = new SelectSlider("samples",Translator.get("SpirographNumSamples"),2000,50,Generator_Lissajous.getNumSamples()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Lissajous_curve'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Lissajous_curve'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Maze_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Maze_Panel.java
@@ -27,7 +27,7 @@ public class Generator_Maze_Panel extends TurtleGeneratorPanel {
 
 		add(field_rows = new SelectSlider("rows",Translator.get("MazeRows"),100,1,generator.getRows()));
 		add(field_columns = new SelectSlider("columns",Translator.get("MazeColumns"),100,1,generator.getCols()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Maze_generation_algorithm'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Maze_generation_algorithm'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_SierpinskiTriangle_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_SierpinskiTriangle_Panel.java
@@ -25,7 +25,7 @@ public class Generator_SierpinskiTriangle_Panel extends TurtleGeneratorPanel {
 		this.generator = generator;
 		
 		add(field_order = new SelectSlider("order",Translator.get("HilbertCurveOrder"),10,1,Generator_SierpinskiTriangle.getOrder()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Spirograph_Panel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_Spirograph_Panel.java
@@ -35,7 +35,7 @@ public class Generator_Spirograph_Panel extends TurtleGeneratorPanel {
 		add(field_minorRadius = new SelectInteger("MinorRadius",Translator.get("SpirographMinorRadius"),Generator_Spirograph.getMinorRadius()));
 		add(field_pScale = new SelectDouble("PScale",Translator.get("SpirographPScale"),Generator_Spirograph.getPScale()));
 		add(field_numSamples = new SelectInteger("NumSamples",Translator.get("SpirographNumSamples"),Generator_Spirograph.getNumSamples()));
-		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Spirograph'>Learn more</a>"));
+		add(new SelectReadOnlyText("url","<a href='https://en.wikipedia.org/wiki/Spirograph'>"+Translator.get("TurtleGenerators.LearnMore.Link.Text")+"</a>"));
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -12,7 +12,7 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer(),"TurtleRenderFactory.DEFAULT"),// not coder friendly but allow later the CI test not to miss this translation keys.
+	DEFAULT("Default", new DefaultTurtleRenderer(),"TurtleRenderFactory.DEFAULT"),
 	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),"TurtleRenderFactory.BARBER_POLE"),
 	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),"TurtleRenderFactory.SEPARATE_LOOP"),
 	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),"TurtleRenderFactory.MARLIN_SIM");

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -12,16 +12,14 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow later the CI test not to miss this translation keys.
-	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),Translator.get("TurtleRenderFactory.BARBER_POLE")),
-	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),Translator.get("TurtleRenderFactory.SEPARATE_LOOP")),
-	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),Translator.get("TurtleRenderFactory.MARLIN_SIM"));
+	DEFAULT("Default", new DefaultTurtleRenderer()),
+	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer()),
+	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer()),
+	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer());
 
 	private final TurtleRenderer turtleRenderer;
 
 	private final String name;
-	
-	private final String translatedText;
 
 	/**
 	 * 
@@ -29,10 +27,9 @@ public enum TurtleRenderFactory {
 	 * @param turtleRenderer
 	 * @param translatedText the text (translated) N.B. : do not rely on the name (used in findByName) to avoid a bad translation (which can give for two elements the same value) to assert any translation may not create issues... 
 	 */
-	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer, String translatedText) {
+	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer) {
 		this.name = name;
 		this.turtleRenderer = turtleRenderer;
-		this.translatedText = translatedText;
 	}
 
 	public TurtleRenderer getTurtleRenderer() {
@@ -43,14 +40,6 @@ public enum TurtleRenderFactory {
 		return name;
 	}
 	
-	/**
-	 * 
-	 * @return The text (translated) to used as text in the GUI ...
-	 */
-	public String getTranslatedText() {
-		return translatedText;
-	}
-
 	public static TurtleRenderFactory findByName(String name) {
 		return Arrays.stream(values())
 				.filter(enumValue -> enumValue.getName().contains(name))

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -25,7 +25,6 @@ public enum TurtleRenderFactory {
 	 * 
 	 * @param name
 	 * @param turtleRenderer
-	 * @param translatedText the text (translated) N.B. : do not rely on the name (used in findByName) to avoid a bad translation (which can give for two elements the same value) to assert any translation may not create issues... 
 	 */
 	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer) {
 		this.name = name;
@@ -39,7 +38,7 @@ public enum TurtleRenderFactory {
 	public String getName() {
 		return name;
 	}
-	
+
 	public static TurtleRenderFactory findByName(String name) {
 		return Arrays.stream(values())
 				.filter(enumValue -> enumValue.getName().contains(name))

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -12,7 +12,7 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow latter the CI test not to miss this traduction keys.
+	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow latter the CI test not to miss this translation keys.
 	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),Translator.get("TurtleRenderFactory.BARBER_POLE")),
 	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),Translator.get("TurtleRenderFactory.SEPARATE_LOOP")),
 	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),Translator.get("TurtleRenderFactory.MARLIN_SIM"));
@@ -21,18 +21,18 @@ public enum TurtleRenderFactory {
 
 	private final String name;
 	
-	private final String traductedText;
+	private final String translatedText;
 
 	/**
 	 * 
 	 * @param name
 	 * @param turtleRenderer
-	 * @param traductedText the text (traducted) N.B. : not base on the name (used in findByName) to avoid a bad traduction (that give for two elements the same value) to assert any traduction may not create issues... 
+	 * @param translatedText the text (translated) N.B. : do not rely on the name (used in findByName) to avoid a bad translation (which can give for two elements the same value) to assert any translation may not create issues... 
 	 */
-	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer, String traductedText) {
+	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer, String translatedText) {
 		this.name = name;
 		this.turtleRenderer = turtleRenderer;
-		this.traductedText = traductedText;
+		this.translatedText = translatedText;
 	}
 
 	public TurtleRenderer getTurtleRenderer() {
@@ -45,10 +45,10 @@ public enum TurtleRenderFactory {
 	
 	/**
 	 * 
-	 * @return The text (traducted) to used as text in the GUI ...
+	 * @return The text (translated) to used as text in the GUI ...
 	 */
-	public String getTraductedText() {
-		return traductedText;
+	public String getTranslatedText() {
+		return translatedText;
 	}
 
 	public static TurtleRenderFactory findByName(String name) {

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -12,7 +12,7 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow latter the CI test not to miss this translation keys.
+	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow later the CI test not to miss this translation keys.
 	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),Translator.get("TurtleRenderFactory.BARBER_POLE")),
 	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),Translator.get("TurtleRenderFactory.SEPARATE_LOOP")),
 	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),Translator.get("TurtleRenderFactory.MARLIN_SIM"));

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -45,7 +45,7 @@ public enum TurtleRenderFactory {
 	
 	/**
 	 * 
-	 * @return The text (translated) to used as text in the GUI ...
+	 * @return The translated text to be used as text in the GUI
 	 */
 	public String getTranslatedText() {
 		return Translator.get(translatKey);

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -1,5 +1,6 @@
 package com.marginallyclever.makelangelo.turtle.turtleRenderer;
 
+import com.marginallyclever.makelangelo.Translator;
 import java.util.Arrays;
 
 import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulationVisualizer;
@@ -11,18 +12,27 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer()),
-	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer()),
-	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer()),
-	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer());
+	DEFAULT("Default", new DefaultTurtleRenderer(),Translator.get("TurtleRenderFactory.DEFAULT")),// not coder friendly but allow latter the CI test not to miss this traduction keys.
+	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),Translator.get("TurtleRenderFactory.BARBER_POLE")),
+	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),Translator.get("TurtleRenderFactory.SEPARATE_LOOP")),
+	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),Translator.get("TurtleRenderFactory.MARLIN_SIM"));
 
 	private final TurtleRenderer turtleRenderer;
 
 	private final String name;
+	
+	private final String traductedText;
 
-	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer) {
+	/**
+	 * 
+	 * @param name
+	 * @param turtleRenderer
+	 * @param traductedText the text (traducted) N.B. : not base on the name (used in findByName) to avoid a bad traduction (that give for two elements the same value) to assert any traduction may not create issues... 
+	 */
+	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer, String traductedText) {
 		this.name = name;
 		this.turtleRenderer = turtleRenderer;
+		this.traductedText = traductedText;
 	}
 
 	public TurtleRenderer getTurtleRenderer() {
@@ -31,6 +41,14 @@ public enum TurtleRenderFactory {
 
 	public String getName() {
 		return name;
+	}
+	
+	/**
+	 * 
+	 * @return The text (traducted) to used as text in the GUI ...
+	 */
+	public String getTraductedText() {
+		return traductedText;
 	}
 
 	public static TurtleRenderFactory findByName(String name) {

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java
@@ -12,23 +12,27 @@ import com.marginallyclever.makelangelo.plotter.marlinSimulation.MarlinSimulatio
  * @author Dan Royer
  */
 public enum TurtleRenderFactory {
-	DEFAULT("Default", new DefaultTurtleRenderer()),
-	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer()),
-	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer()),
-	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer());
+	DEFAULT("Default", new DefaultTurtleRenderer(),"TurtleRenderFactory.DEFAULT"),// not coder friendly but allow later the CI test not to miss this translation keys.
+	BARBER_POLE("Barber pole", new BarberPoleTurtleRenderer(),"TurtleRenderFactory.BARBER_POLE"),
+	SEPARATE_LOOP("Separate loops",new SeparateLoopTurtleRenderer(),"TurtleRenderFactory.SEPARATE_LOOP"),
+	MARLIN_SIM("Marlin simulation",new MarlinSimulationVisualizer(),"TurtleRenderFactory.MARLIN_SIM");
 
 	private final TurtleRenderer turtleRenderer;
 
 	private final String name;
+	
+	private final String translatKey;
 
 	/**
 	 * 
 	 * @param name
 	 * @param turtleRenderer
+	 *  @param translatKey The key used with Translator.get in getTranslatedText to obtaine the translated Text.
 	 */
-	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer) {
+	TurtleRenderFactory(String name, TurtleRenderer turtleRenderer, String translatKey) {
 		this.name = name;
 		this.turtleRenderer = turtleRenderer;
+		this.translatKey = translatKey;
 	}
 
 	public TurtleRenderer getTurtleRenderer() {
@@ -37,6 +41,14 @@ public enum TurtleRenderFactory {
 
 	public String getName() {
 		return name;
+	}
+	
+	/**
+	 * 
+	 * @return The text (translated) to used as text in the GUI ...
+	 */
+	public String getTranslatedText() {
+		return Translator.get(translatKey);
 	}
 
 	public static TurtleRenderFactory findByName(String name) {

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -239,6 +239,11 @@
 	</string>
 
 	<string>
+		<key>PaperSettings.Title</key>
+		<value>Paper settings</value>
+		<hint>Paper settings panel title</hint>
+	</string>
+	<string>
 		<key>PaperSettings.PaperSize</key>
 		<value>Paper Size</value>
 		<hint>Paper settings panel</hint>
@@ -2007,7 +2012,7 @@
 	<string>
 		<key>OpenPaperSettings</key>
 		<value>Paper settings</value>
-		<hint></hint>
+		<hint>MenuItem</hint>
 	</string>
 	
 	<string>
@@ -2082,5 +2087,14 @@
 		<value>Error</value>
 		<hint>Dialog</hint>
 	</string>
+
+
+<!--
+    <string>
+        <key></key>
+        <value></value>
+        <hint></hint>
+    </string>
+ -->                
 
 </language>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2102,7 +2102,7 @@
     <string>
         <key>TurtleRenderFactory.BARBER_POLE</key>
         <value>Barber pole</value>
-        <hint></hint>
+        <hint>Barber pole (red white blue, stripes)</hint>
     </string>
     <string>
         <key>TurtleRenderFactory.SEPARATE_LOOP</key>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2094,6 +2094,26 @@
     </string>
 
 
+    <string>
+        <key>TurtleRenderFactory.DEFAULT</key>
+        <value>Default</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.BARBER_POLE</key>
+        <value>Barber pole</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.SEPARATE_LOOP</key>
+        <value>Separate loops</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.MARLIN_SIM</key>
+        <value>Marlin simulation</value>
+        <hint></hint>
+    </string>
 
 <!--
     <string>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2114,6 +2114,12 @@
         <value>Marlin simulation</value>
         <hint></hint>
     </string>
+    <string>
+        <key>TurtleGenerators.LearnMore.Link.Text</key>
+        <value>Learn more</value>
+        <hint>Used in many Generator Panel as link text to Wikipedia URLs</hint>
+    </string>
+
 
 <!--
     <string>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2087,6 +2087,12 @@
 		<value>Error</value>
 		<hint>Dialog</hint>
 	</string>
+    <string>
+        <key>PlotterSettingsPanel.Title</key>
+		<value>Plotter settings</value>
+        <hint>panel title</hint>
+    </string>
+
 
 
 <!--

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2102,7 +2102,7 @@
     <string>
         <key>TurtleRenderFactory.BARBER_POLE</key>
         <value>Barber pole</value>
-        <hint>Barber pole (red white blue, stripes)</hint>
+        <hint>Barber pole (red, blue)</hint>
     </string>
     <string>
         <key>TurtleRenderFactory.SEPARATE_LOOP</key>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2782,8 +2782,8 @@
     </string>
     <string>
         <key>TurtleRenderFactory.BARBER_POLE</key>
-        <value>Poteau de barbier</value>
-        <hint></hint>
+        <value>Enseigne de barbier (rouge, blanc, bleu.)</value>
+        <hint>Barber pole (red white blue, stripes)</hint>
     </string>
     <string>
         <key>TurtleRenderFactory.SEPARATE_LOOP</key>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2768,6 +2768,12 @@
         <value>Paramètres papier</value>
         <hint>Paper settings panel title</hint>
     </string>
+    <string>
+        <key>PlotterSettingsPanel.Title</key>
+        <value>Paramètres du traceur</value>
+        <hint>panel title</hint>
+    </string>
+
     
 <!--
     <string>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2795,6 +2795,11 @@
         <value>Simulation vitesses marlin</value>
         <hint></hint>
     </string>
+    <string>
+        <key>TurtleGenerators.LearnMore.Link.Text</key>
+        <value>En savoir plus</value>
+        <hint>Used in many Generator Panel as link text to Wikipedia URLs</hint>
+    </string>
 
 <!--
     <string>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2798,7 +2798,7 @@
     <string>
         <key>TurtleGenerators.LearnMore.Link.Text</key>
         <value>En savoir plus</value>
-        <hint>Used in many Generator Panel as link text to Wikipedia URLs</hint>
+        <hint>Utilisé dans différents panels comme texte de lien vers Wikipedia</hint>
     </string>
 
 <!--

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2782,8 +2782,8 @@
     </string>
     <string>
         <key>TurtleRenderFactory.BARBER_POLE</key>
-        <value>Enseigne de barbier (rouge, blanc, bleu.)</value>
-        <hint>Barber pole (red white blue, stripes)</hint>
+        <value>Enseigne de barbier (rouge, bleu)</value>
+        <hint>Barber pole (red, blue)</hint>
     </string>
     <string>
         <key>TurtleRenderFactory.SEPARATE_LOOP</key>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2775,6 +2775,27 @@
     </string>
 
     
+    <string>
+        <key>TurtleRenderFactory.DEFAULT</key>
+        <value>Défaut</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.BARBER_POLE</key>
+        <value>Poteau de barbier</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.SEPARATE_LOOP</key>
+        <value>Boucles séparées</value>
+        <hint></hint>
+    </string>
+    <string>
+        <key>TurtleRenderFactory.MARLIN_SIM</key>
+        <value>Simulation vitesses marlin</value>
+        <hint></hint>
+    </string>
+
 <!--
     <string>
         <key></key>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -2763,4 +2763,18 @@
         <value>Faire un don PayPal</value>
         <hint>About Menu</hint>
     </string>
+    <string>
+        <key>PaperSettings.Title</key>
+        <value>Paramètres papier</value>
+        <hint>Paper settings panel title</hint>
+    </string>
+    
+<!--
+    <string>
+        <key></key>
+        <value></value>
+        <hint></hint>
+    </string>
+ -->
+ 
 </language>


### PR DESCRIPTION
a try to resolve some elements in https://github.com/MarginallyClever/Makelangelo-software/issues/513

I am not satisfied with what I propose for the enum.

https://github.com/MarginallyClever/Makelangelo-software/blob/c4b369c1713061acd0302a6fd4fdc881b40fe1d7/src/main/java/com/marginallyclever/makelangelo/turtle/turtleRenderer/TurtleRenderFactory.java#L14-L17

As I want to ensure that the CI test identifies the keys, I need a Translator.get("...") with simple fixed String.
But that makes the encoding and/or the enum unpleasant to look at from a code point of view.

Any ideas for finding a better compromise? or I drop the guarantee of the control of the translation keys (and the fact of explaining in the enum which element is used for the translation keys and therefore in the event of modification of the enum it will be necessary without remembering ...) ?