### PR TITLE
Work on bug 513 xml validation fix and allowing empty value for a translation

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Translator.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Translator.java
@@ -197,6 +197,7 @@ public final class Translator {
 			lang.loadFromInputStream(stream);
 		} catch(Exception e) {
 			logger.error("Failed to load {}", actualFilename);
+			logger.debug("{}",e);// To log the Exception stack in debug/dev mode.
 			// if the xml file is invalid then an exception can occur.
 			// make sure lang is empty in case of a partial-load failure.
 			lang = new TranslatorLanguage();

--- a/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
+++ b/src/main/java/com/marginallyclever/makelangelo/TranslatorLanguage.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -127,7 +128,13 @@ public class TranslatorLanguage {
 		NodeList nl = ele.getElementsByTagName(tagName);
 		if (nl != null && nl.getLength() > 0) {
 			Element el = (Element) nl.item(0);
-			textVal = el.getFirstChild().getNodeValue();
+			// to allow empty value as translation 
+			final Node firstChild = el.getFirstChild();
+			if ( firstChild != null){
+				textVal = firstChild.getNodeValue();
+			}else{				
+				textVal = "";
+			}
 		}
 		textVal = textVal.replace("\\n", "\n");
 		return textVal;

--- a/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/CartesianButtons.java
+++ b/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/CartesianButtons.java
@@ -3,6 +3,8 @@ package com.marginallyclever.makelangelo.plotter.plotterControls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.marginallyclever.makelangelo.Translator;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -108,7 +110,7 @@ public class CartesianButtons extends JComponent {
 			--v;
 		}
 
-		labels[ZONE_CENTER] = "Home";
+		labels[ZONE_CENTER] = Translator.get( "CartesianButtons.buttonCenter" );
 	}
 
 	@Override

--- a/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/JogInterface.java
+++ b/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/JogInterface.java
@@ -43,10 +43,7 @@ public class JogInterface extends JPanel {
 		
 		bCartesian.addActionListener((e)->{
 	    	int id = e.getID();
-	    	if(CartesianButtons.isCenterZone(id)) {
-	    		findHome();
-	    		return;
-	    	}
+	    	if(CartesianButtons.isCenterZone(id)) return;
 	    	int q=CartesianButtons.getQuadrant(id);
 	    	int z=CartesianButtons.getZone(id);
 	    	int x,y;

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -2083,4 +2083,10 @@
 		<hint>Dialog</hint>
 	</string>
 
+	<string>
+		<key>CartesianButtons.buttonCenter</key>
+		<value></value>
+		<hint>jog controls</hint>
+	</string>
+
 </language>

--- a/src/test/resources/translator/language_no_dup_key.xsd
+++ b/src/test/resources/translator/language_no_dup_key.xsd
@@ -21,7 +21,7 @@
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element type="stringNotEmpty" name="key"/>
-                            <xs:element type="stringNotEmpty" name="value"/>
+                            <xs:element type="xs:string" name="value"/><!-- type from "stringNotEmpty" changed to "xs:string" to remove restriction to allow empty value -->
                             <xs:element type="xs:string" name="hint" minOccurs="0"/>
                         </xs:sequence>
                     </xs:complexType>                   


### PR DESCRIPTION
This adding to #530 modification, normaly allow #530 to pass CI test to allow empty value for translation in the xml validation (xsd shema with to hight restriction for the contente)  and in the load (TranslatorLanguage.java) of a language file.