### PR TITLE
Linux for some java lookandfeel bug fix

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -20,9 +20,8 @@ import org.slf4j.LoggerFactory;
 public class Select extends JPanel {
 	private static final long serialVersionUID = 5289951183273734129L;
 	private static final Logger logger = LoggerFactory.getLogger(Select.class);
-	private static boolean haveLAndFIssueBeenReported = false;
 	
-	private List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
+	private List<PropertyChangeListener> propertyChangeListeners = null;
 		
 	protected Select(String name) {
 		super(new BorderLayout(2,0));
@@ -31,25 +30,25 @@ public class Select extends JPanel {
 	
 	// OBSERVER PATTERN
 	
-	public void addPropertyChangeListener(PropertyChangeListener p) {
-		if ( propertyChangeListeners == null){ 
-			// PPAC37 to avoid "-nolf" : as some linux Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
+	public void addPropertyChangeListener(PropertyChangeListener p) {	
+		if ( propertyChangeListeners == null ){// PPAC37 to avoid "-nolf" : as some linux Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
 			// can run this overrided methode befor the class is fully initialised ...
-			// (But then tooltips color to change TODO.)
 			propertyChangeListeners = new ArrayList<>();
-			if ( !haveLAndFIssueBeenReported ) {
-				haveLAndFIssueBeenReported = true;
-				logger.debug("need \"-nolf\" due to l&f \"{}\"",UIManager.getLookAndFeel().getClass().getCanonicalName());
-			}
 		}
 		propertyChangeListeners.add(p);
 	}
 	
 	public void removePropertyChangeListener(PropertyChangeListener p) {
+		if ( propertyChangeListeners == null ){
+			propertyChangeListeners = new ArrayList<>();
+		}
 		propertyChangeListeners.remove(p);
 	}
 	
 	protected void firePropertyChange(Object oldValue,Object newValue) {
+		if ( propertyChangeListeners == null ){
+			propertyChangeListeners = new ArrayList<>();
+		}
 		PropertyChangeEvent evt = new PropertyChangeEvent(this,this.getName(),oldValue,newValue);
 		for( PropertyChangeListener p : propertyChangeListeners ) {
 			p.propertyChange(evt);

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.JPanel;
 import javax.swing.UIManager;
@@ -20,7 +21,7 @@ public class Select extends JPanel {
 	private static final long serialVersionUID = 5289951183273734129L;
 	private static final Logger logger = LoggerFactory.getLogger(Select.class);
 	
-	private ArrayList<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
+	private List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
 		
 	protected Select(String name) {
 		super(new BorderLayout(2,0));

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 public class Select extends JPanel {
 	private static final long serialVersionUID = 5289951183273734129L;
 	private static final Logger logger = LoggerFactory.getLogger(Select.class);
+	private static boolean haveLAndFIssueBeenReported = false;
 	
 	private List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
 		
@@ -36,7 +37,10 @@ public class Select extends JPanel {
 			// can run this overrided methode befor the class is fully initialised ...
 			// (But then tooltips color to change TODO.)
 			propertyChangeListeners = new ArrayList<>();
-			logger.debug("need \"-nolf\" due to l&f \"{}\"",UIManager.getLookAndFeel().getClass().getCanonicalName());
+			if ( !haveLAndFIssueBeenReported ) {
+				haveLAndFIssueBeenReported = true;
+				logger.debug("need \"-nolf\" due to l&f \"{}\"",UIManager.getLookAndFeel().getClass().getCanonicalName());
+			}
 		}
 		propertyChangeListeners.add(p);
 	}

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -7,9 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JPanel;
-import javax.swing.UIManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for all Select.  A Select is a UI panel item the user can control.
@@ -18,9 +15,7 @@ import org.slf4j.LoggerFactory;
  * @since 7.24.0
  */
 public class Select extends JPanel {
-	private static final long serialVersionUID = 5289951183273734129L;
-	private static final Logger logger = LoggerFactory.getLogger(Select.class);
-	
+	private static final long serialVersionUID = 5289951183273734129L;	
 	private List<PropertyChangeListener> propertyChangeListeners = null;
 		
 	protected Select(String name) {
@@ -30,14 +25,16 @@ public class Select extends JPanel {
 	
 	// OBSERVER PATTERN
 	
+	@Override
 	public void addPropertyChangeListener(PropertyChangeListener p) {	
 		if ( propertyChangeListeners == null ){
-		// some Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel") can run this override method before the class is fully initialized ...
+			// some Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel") can run this override method before the class is fully initialized ...
 			propertyChangeListeners = new ArrayList<>();
 		}
 		propertyChangeListeners.add(p);
 	}
 	
+	@Override
 	public void removePropertyChangeListener(PropertyChangeListener p) {
 		if ( propertyChangeListeners == null ){
 			propertyChangeListeners = new ArrayList<>();

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -31,8 +31,8 @@ public class Select extends JPanel {
 	// OBSERVER PATTERN
 	
 	public void addPropertyChangeListener(PropertyChangeListener p) {	
-		if ( propertyChangeListeners == null ){// PPAC37 to avoid "-nolf" : as some linux Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
-			// can run this overrided methode befor the class is fully initialised ...
+		if ( propertyChangeListeners == null ){
+		// some Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel") can run this override method before the class is fully initialized ...
 			propertyChangeListeners = new ArrayList<>();
 		}
 		propertyChangeListeners.add(p);

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -31,7 +31,9 @@ public class Select extends JPanel {
 	
 	public void addPropertyChangeListener(PropertyChangeListener p) {
 		if ( propertyChangeListeners == null){ 
-			// PPAC37 to avoid "-nolf" : as some linux Look and Feel can run this overrided methode befor the class is fully initialised ...			
+			// PPAC37 to avoid "-nolf" : as some linux Look and Feel (like "com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
+			// can run this overrided methode befor the class is fully initialised ...
+			// (But then tooltips color to change TODO.)
 			propertyChangeListeners = new ArrayList<>();
 			logger.debug("need \"-nolf\" due to l&f \"{}\"",UIManager.getLookAndFeel().getClass().getCanonicalName());
 		}

--- a/src/main/java/com/marginallyclever/makelangelo/select/Select.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/Select.java
@@ -6,6 +6,9 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 
 import javax.swing.JPanel;
+import javax.swing.UIManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for all Select.  A Select is a UI panel item the user can control.
@@ -15,7 +18,9 @@ import javax.swing.JPanel;
  */
 public class Select extends JPanel {
 	private static final long serialVersionUID = 5289951183273734129L;
-	private ArrayList<PropertyChangeListener> propertyChangeListeners = new ArrayList<PropertyChangeListener>();
+	private static final Logger logger = LoggerFactory.getLogger(Select.class);
+	
+	private ArrayList<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
 		
 	protected Select(String name) {
 		super(new BorderLayout(2,0));
@@ -25,6 +30,11 @@ public class Select extends JPanel {
 	// OBSERVER PATTERN
 	
 	public void addPropertyChangeListener(PropertyChangeListener p) {
+		if ( propertyChangeListeners == null){ 
+			// PPAC37 to avoid "-nolf" : as some linux Look and Feel can run this overrided methode befor the class is fully initialised ...			
+			propertyChangeListeners = new ArrayList<>();
+			logger.debug("need \"-nolf\" due to l&f \"{}\"",UIManager.getLookAndFeel().getClass().getCanonicalName());
+		}
 		propertyChangeListeners.add(p);
 	}
 	


### PR DESCRIPTION
Under linux Ubuntu ( 18.04 ? ) 
The default systeme LookAndFeel "com.sun.java.swing.plaf.gtk.GTKLookAndFeel" create a NPE on some Panel loading.

Using "-nolf" commande line argument is a way to avoid it but to be more user friendly ...

This is a "quick/bad fix" as it do not resolve the root issue.

![image](https://user-images.githubusercontent.com/94939582/154227799-6d7b62fd-4d6f-4a9f-9a8a-e19ba19e4151.png)


But the LookAndFeel have other issues : like the tooltips font color is the same as the tooltips background color ... 
* [x] a solution for the tooltips (EDIT : WILL NOT BE DONE ... i have try but no sucess)
![image](https://user-images.githubusercontent.com/94939582/154227776-ae7b6ef2-8f96-48bb-8ecf-5302b21c9b95.png)

