### PR TITLE
🐛 fix zoom movement

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/preview/PreviewPanel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/preview/PreviewPanel.java
@@ -42,11 +42,11 @@ public class PreviewPanel extends GLJPanel implements GLEventListener {
 	// private boolean mouseIn=false;
 	private int buttonPressed = MouseEvent.NOBUTTON;
 	private int mouseOldX, mouseOldY;
+	private int mouseLastZoomDirection = 0;
 
 	// OpenGL stuff
 	private GLU glu;
 	private FPSAnimator animator;
-
 
 	public PreviewPanel() {
 		super();
@@ -71,10 +71,19 @@ public class PreviewPanel extends GLJPanel implements GLEventListener {
 			@Override
 			public void mouseWheelMoved(MouseWheelEvent e) {
 				int notches = e.getWheelRotation();
+				if (notches == 0) {
+					return;
+				}
 				if (notches < 0) {
-					camera.zoomIn();
-				} else if (notches > 0) {
-					camera.zoomOut();
+					if (mouseLastZoomDirection == -1) {
+						camera.zoomIn();
+					}
+					mouseLastZoomDirection = -1;
+				} else {
+					if (mouseLastZoomDirection == 1) {
+						camera.zoomOut();
+					}
+					mouseLastZoomDirection = 1;
 				}
 				repaint();
 			}


### PR DESCRIPTION
When zooming in with the track pad, sometimes it zoom out and vice versa.
Here is a fix to ignore small movement in the reverse direction.