### PR TITLE
Named and or instance number turtle 

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
+++ b/src/main/java/com/marginallyclever/makelangelo/Makelangelo.java
@@ -130,6 +130,7 @@ public final class Makelangelo {
 	private DropTarget dropTarget;
 
 	public Makelangelo() {
+		currentInstance = this;
 		logger.debug("Locale={}", Locale.getDefault().toString());
 		logger.debug("Headless={}", (GraphicsEnvironment.isHeadless()?"Y":"N"));
 		VERSION = PropertiesFileHelper.getMakelangeloVersion();
@@ -868,11 +869,17 @@ public final class Makelangelo {
         labelRangeMax.setText(Integer.toString(top));
 	}
 
+	String mainFram_pos_title = "";
 	//  For thread safety this method should be invoked from the event-dispatching thread.
 	private void createAppWindow() {
 		logger.debug("Creating GUI...");
+		if ( "true".equalsIgnoreCase(System.getenv("DEV"))){
+			mainFram_pos_title = getFullVersionString();
+		}else{
+			mainFram_pos_title = getLiteVersionString();
+		}
 
-		mainFrame = new JFrame(Translator.get("TitlePrefix") + " " + VERSION);
+		mainFrame = new JFrame(mainFram_pos_title);
 		mainFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 		mainFrame.addWindowListener(new WindowAdapter() {
 			@Override
@@ -1059,6 +1066,7 @@ public final class Makelangelo {
 	}
 
 	public void setTurtle(Turtle turtle) {
+		mainFrame.setTitle(turtle.getName()+" - "+mainFram_pos_title);
 		myTurtle = turtle;
 		myTurtleRenderer.setTurtle(turtle);
 		int top = turtle.history.size();
@@ -1090,5 +1098,21 @@ public final class Makelangelo {
 			Makelangelo makelangeloProgram = new Makelangelo();
 			makelangeloProgram.run();
 		});
+	}
+	
+	public String getFullVersionString(){
+		return getLiteVersionString()+ " ("+DETAILED_VERSION+")";		
+	}
+	public String getLiteVersionString(){
+		return Translator.get("TitlePrefix") + " " +VERSION;		
+	}
+	
+	private static Makelangelo currentInstance = null;
+	
+	public static String staticgetFullVersionString(){
+		if ( currentInstance != null){
+			return currentInstance.getFullVersionString();
+		}
+		return "";
 	}
 }

--- a/src/main/java/com/marginallyclever/makelangelo/SaveDialog.java
+++ b/src/main/java/com/marginallyclever/makelangelo/SaveDialog.java
@@ -24,6 +24,7 @@ public class SaveDialog {
 	}
 	
 	public void run(Turtle t,JFrame parent) throws Exception {
+		fc.setSelectedFile(new File(t.getName()));// TODO only get the name to avoid changing the save path if the name start with a path.
 		if (fc.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
 			String selectedFile = fc.getSelectedFile().getAbsolutePath();
 			String withExtension = addExtension(selectedFile,((FileNameExtensionFilter)fc.getFileFilter()).getExtensions());

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/imageConverter/Converter_Boxxy.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/imageConverter/Converter_Boxxy.java
@@ -62,6 +62,11 @@ public class Converter_Boxxy extends ImageConverter {
 		if (steps < 1) steps = 1;
 
 		turtle = new Turtle();
+		turtle.setName(getName()+" ("
+				+ "BSize=" + getBoxMasSize() + " "
+				+ "Coff=" + getCutoff() + " "
+				+ ")");// TODO (may be better in the extended class ) want a constant name ( whatever the language used) with the paraméters name and value ) 
+		
 
 		double lowpass = cutoff/255.0;
 		

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/LoadFilePanel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/LoadFilePanel.java
@@ -66,7 +66,7 @@ public class LoadFilePanel extends JPanel implements PreviewListener {
 			if (ConvertImagePanel.isFilenameForAnImage(filename)) {
 				TransformedImage image = new TransformedImage( ImageIO.read(new FileInputStream(filename)) );
 
-				myConvertImage = new ConvertImagePanel(myPaper, image);
+				myConvertImage = new ConvertImagePanel(myPaper, image,filename);
 				myConvertImage.setBorder(BorderFactory.createTitledBorder(ConvertImagePanel.class.getSimpleName()));
 				myConvertImage.addActionListener(this::notifyListeners);
 				mySubPanel.removeAll();

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/image/ConvertImagePanel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/image/ConvertImagePanel.java
@@ -52,7 +52,9 @@ public class ConvertImagePanel extends JPanel implements PreviewListener, Select
 	private int workerCount = 0;
 	private ProgressMonitor pm;
 	
-	public ConvertImagePanel(Paper paper,TransformedImage image) {
+	private String imgNameForTurtle = null;
+	
+	public ConvertImagePanel(Paper paper,TransformedImage image, String imgNameForTurtle) {
 		super();
 		myPaper = paper;
 		myImage = image;
@@ -106,6 +108,8 @@ public class ConvertImagePanel extends JPanel implements PreviewListener, Select
 
 		int first = (styleNames!=null ? styleNames.getSelectedIndex() : 0);
 		changeConverter(ImageConverterFactory.list[first]);
+		
+		this.imgNameForTurtle = imgNameForTurtle;
 	}
 	
 	private JComboBox<String> getStyleSelection() {
@@ -357,7 +361,7 @@ public class ConvertImagePanel extends JPanel implements PreviewListener, Select
 		TransformedImage image = new TransformedImage(ImageIO.read(new FileInputStream("C:/Users/aggra/Documents/drawbot art/grumpyCat.jpg")));
 		JFrame frame = new JFrame(ConvertImagePanel.class.getSimpleName());
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		frame.add(new ConvertImagePanel(new Paper(),image));
+		frame.add(new ConvertImagePanel(new Paper(),image,"grumpyCat"));
 		frame.pack();
 		frame.setVisible(true);
 	}

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadDXF.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadDXF.java
@@ -123,7 +123,7 @@ public class LoadDXF implements TurtleLoader {
 	}
 	
 	@Override
-	public Turtle load(InputStream in) throws Exception {
+	public Turtle load(InputStream in, String nameForTurlte) throws Exception {
 		logger.debug("Loading...");
 
 		// Read in the DXF file
@@ -135,6 +135,7 @@ public class LoadDXF implements TurtleLoader {
 		imageCenterY = (bounds.getMaximumY() + bounds.getMinimumY()) / 2.0;
 
 		myTurtle = new Turtle();
+		myTurtle.setName(nameForTurlte);
 		
 		// convert each entity
 		Iterator<?> layerIter = doc.getDXFLayerIterator();

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadGCode.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadGCode.java
@@ -38,8 +38,9 @@ public class LoadGCode implements TurtleLoader {
 	}
 	
 	@Override
-	public Turtle load(InputStream in) throws Exception {
+	public Turtle load(InputStream in, String nameForTurlte) throws Exception {
 		Turtle turtle = new Turtle();
+		turtle.setName(nameForTurlte);
 		ColorRGB penDownColor = turtle.getColor();
 		double scaleXY=1;
 		boolean isAbsolute=true;

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadSVG.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadSVG.java
@@ -50,13 +50,14 @@ public class LoadSVG implements TurtleLoader {
 	}
 
 	@Override
-	public Turtle load(InputStream in) throws Exception {
+	public Turtle load(InputStream in, String nameForTurlte) throws Exception {
 		logger.debug("Loading...");
 		
 		Document document = newDocumentFromInputStream(in);
 		initSVGDOM(document);
 		
 	    myTurtle = new Turtle();
+		myTurtle.setName(nameForTurlte);
 		myTurtle.setColor(new ColorRGB(0,0,0));
 		parseAll(document);
 		

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadScratch2.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadScratch2.java
@@ -65,10 +65,11 @@ public class LoadScratch2 implements TurtleLoader {
 	}
 	
 	@Override
-	public Turtle load(InputStream in) throws Exception {
+	public Turtle load(InputStream in, String nameForTurlte) throws Exception {
 		logger.debug("Loading...");
 
 		turtle = new Turtle();
+		turtle.setName(nameForTurlte);
 		indent=0;
 		
 		JSONObject tree = getTreeFromInputStream(in);

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadScratch3.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/LoadScratch3.java
@@ -114,7 +114,7 @@ public class LoadScratch3 implements TurtleLoader {
 	}
 	
 	@Override
-	public Turtle load(InputStream in) throws Exception {
+	public Turtle load(InputStream in, String nameForTurlte) throws Exception {
 		logger.debug("Loading...");
 		JSONObject tree = getTreeFromInputStream(in);
 		
@@ -125,7 +125,7 @@ public class LoadScratch3 implements TurtleLoader {
 		readScratchLists(tree);
 		findBlocks(tree);
 		readScratchProcedures();
-		readScratchInstructions();
+		readScratchInstructions(nameForTurlte);
 
 		return myTurtle;
 	}
@@ -193,9 +193,10 @@ public class LoadScratch3 implements TurtleLoader {
 	 * @param tree the JSONObject tree read from the project.json/zip file.
 	 * @throws Exception
 	 */
-	private void readScratchInstructions() throws Exception {
+	private void readScratchInstructions(String nameForTurlte) throws Exception {
 		logger.trace("readScratchInstructions ( and do a flagclicked {} times ) ",nbClicOnTheGreenFlag);
 		myTurtle = new Turtle();// needed to be init here in case multiple "event_whenflagclicked"
+		myTurtle.setName(nameForTurlte);
 		int nbGreenFlagParsed_Total = 0;
 		for (int i = 0; i < nbClicOnTheGreenFlag; i++) {
 			// find the first block with opcode=event_whenflagclicked.

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/TurtleFactory.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/TurtleFactory.java
@@ -28,10 +28,11 @@ public class TurtleFactory {
 
 		for( TurtleLoader loader : loaders ) {
 			if(isValidExtension(filename,loader.getFileNameFilter())) {
-				FileInputStream in = new FileInputStream(filename);
-				Turtle result = loader.load(in);
-				in.close();
-				return result;
+				try (FileInputStream in = new FileInputStream(filename)) {// ? already done by collis ... i maybe on an old revision ...
+					Turtle result = loader.load(in, filename);// todo if not in dev mode not the full filename but only the new File(filename).getFileName() with no extension ?
+					return result;
+				}
+				
 			}
 		}
 		throw new IllegalStateException("TurtleFactory could not load '"+filename+"'.");

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/TurtleLoader.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/io/vector/TurtleLoader.java
@@ -25,5 +25,5 @@ public interface TurtleLoader {
 	 * @param inputStream source of image
 	 * @return true if load successful.
 	 */
-	public Turtle load(InputStream inputStream) throws Exception;
+	public Turtle load(InputStream inputStream, String nameForTurtle) throws Exception;
 }

--- a/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_KochCurve.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makeArt/turtleGenerator/Generator_KochCurve.java
@@ -43,6 +43,7 @@ public class Generator_KochCurve extends TurtleGenerator {
 		yMin = -v;
 
 		Turtle turtle = new Turtle();
+		turtle.setName(getName()+" (order="+getOrder()+")");// TODO (may be better in the extended class ) want a constant name ( whatever the language used) with the paraméters name and value ) 
 		
 		double xx = xMax - xMin;
 		double yy = yMax - yMin;

--- a/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/SaveGCode.java
+++ b/src/main/java/com/marginallyclever/makelangelo/plotter/plotterControls/SaveGCode.java
@@ -1,5 +1,6 @@
 package com.marginallyclever.makelangelo.plotter.plotterControls;
 
+import com.marginallyclever.makelangelo.Makelangelo;
 import com.marginallyclever.makelangelo.plotter.Plotter;
 import com.marginallyclever.makelangelo.turtle.Turtle;
 import com.marginallyclever.makelangelo.turtle.TurtleMove;
@@ -40,6 +41,7 @@ public class SaveGCode {
 	}
 
 	public void run(Turtle turtle, Plotter robot, JFrame parent) throws Exception {
+		fc.setSelectedFile(new File(turtle.getName()));// TODO only get the name to avoid changing the save path if the name start with a path.
 		if (fc.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
 			String selectedFile = fc.getSelectedFile().getAbsolutePath();
 			String fileWithExtension = addExtension(selectedFile,((FileNameExtensionFilter)fc.getFileFilter()).getExtensions());
@@ -62,11 +64,54 @@ public class SaveGCode {
 		try (Writer out = new OutputStreamWriter(new FileOutputStream(filename))) {
 
 			SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
+			// TODO as comment engine generator ( "Makelangelo VERSION DETAILDVERSION" )
+			/* TODO like Ultimaker cura ??? pre
+			;FLAVOR:Marlin
+;TIME:8627
+;Filament used: 8.33533m
+;Layer height: 0.2
+;MINX:9.366
+;MINY:109.8
+;MINZ:0.2
+;MAXX:96.724
+;MAXY:197.158
+;MAXZ:45
+;ARCWELDERPROCESSED
+; Postprocessed by [ArcWelder](https://github.com/FormerLurker/ArcWelderLib)
+; Copyright(C) 2020 - Brad Hochgesang
+; resolution=0.05mm
+; path_tolerance=5%
+; max_radius=1000000.00mm
+; default_xyz_precision=3
+; default_e_precision=5
+
+;Generated with Cura_SteamEngine 4.10.0
+
+			*/
+			out.write(";Generated with  " + Makelangelo.staticgetFullVersionString() + "\n");
 			Date date = new Date(System.currentTimeMillis());
 			out.write("; " + formatter.format(date) + "\n");
+			out.write("; " + turtle.getName() + "\n");
+			// TODO as comment env states ( Paper Size , plotter type,  plotter config , ...)
 			// TODO MarlinPlotterInterface.getFindHomeString()?
-			out.write("G28\n");  // go home
+			out.write("; " + robot.toString() + "\n");
+			// TODO start gcode ( Like M201 ... M92 ...
+			// https://marlinfw.org/docs/gcode/M092.html Set Axis Steps-per-unit
+			// https://marlinfw.org/docs/gcode/M117.html Set LCD Message
+			// https://marlinfw.org/docs/gcode/M220.html Set Feedrate Percentage
+			// ...
+			out.write("G28\n");  // go home 
 
+			/* ???
+			
+;LAYER_COUNT:225
+;LAYER:0
+M107
+;MESH:spheres_v0001_3m5m4_.stl
+G0 F3600 X53.011 Y180.863 Z0.2
+;TYPE:WALL-INNER
+			  
+			 */
 			boolean isUp = true;
 
 			TurtleMove previousMovement = null;
@@ -94,14 +139,40 @@ public class SaveGCode {
 						previousMovement = m;
 					}
 					case TurtleMove.TOOL_CHANGE -> {
+						// ?? ;TIME_ELAPSED:8627.004434
+						// TODO tool change start gcode ( like i whant a bip M300 and/or somthing else like a park position ...)
 						out.write(MarlinPlotterInterface.getPenUpString(robot) + "\n");
 						out.write(MarlinPlotterInterface.getToolChangeString(m.getColor().toInt()) + "\n");
+						// todo tool change end gcode
 					}
 				}
 			}
 			if (!isUp) out.write(MarlinPlotterInterface.getPenUpString(robot) + "\n");
 		}
+		//TODO endgcode
 
+		/* TODO like Ultimaker Cura post
+		;End of Gcode
+;SETTING_3 {"global_quality": "[general]\\nversion = 4\\nname = Draft #2 Voxel e
+;SETTING_3 leph t01 #2\\ndefinition = vertex_k8400\\n\\n[metadata]\\ntype = qual
+;SETTING_3 ity_changes\\nquality_type = draft\\nsetting_version = 17\\n\\n[value
+;SETTING_3 s]\\nacceleration_enabled = False\\nadhesion_type = none\\narcwelder_
+;SETTING_3 enable = True\\nlayer_height_0 = 0.2\\nspeed_slowdown_layers = 1\\nsu
+;SETTING_3 pport_enable = False\\nsupport_structure = tree\\n\\n", "extruder_qua
+;SETTING_3 lity": ["[general]\\nversion = 4\\nname = Draft #2 Voxel eleph t01 #2
+;SETTING_3 \\ndefinition = vertex_k8400\\n\\n[metadata]\\ntype = quality_changes
+;SETTING_3 \\nquality_type = draft\\nintent_category = default\\nposition = 0\\n
+;SETTING_3 setting_version = 17\\n\\n[values]\\nbrim_line_count = 12\\ncool_min_
+;SETTING_3 layer_time = 2\\ncool_min_speed = 40\\nfill_outline_gaps = True\\nfil
+;SETTING_3 ter_out_tiny_gaps = False\\ninfill_pattern = grid\\ninfill_sparse_den
+;SETTING_3 sity = 25\\nlayer_start_x = 200\\nlayer_start_y = 200\\nmaterial_fina
+;SETTING_3 l_print_temperature = 185.0\\nmaterial_flow = 94.0\\nmaterial_flow_la
+;SETTING_3 yer_0 = 94.0\\nmaterial_initial_print_temperature = 190.0\\nmaterial_
+;SETTING_3 print_temperature = 190.0\\nretraction_amount = 2.0\\nretraction_enab
+;SETTING_3 le = True\\nskin_material_flow = 94.0\\nspeed_print = 80\\nspeed_z_ho
+;SETTING_3 p = 5\\ntravel_avoid_supports = True\\nzig_zaggify_infill = True\\n\\
+;SETTING_3 n"]}
+		*/
 		logger.debug("done.");
 	}
 }

--- a/src/main/java/com/marginallyclever/makelangelo/turtle/Turtle.java
+++ b/src/main/java/com/marginallyclever/makelangelo/turtle/Turtle.java
@@ -33,6 +33,14 @@ public class Turtle implements Cloneable {
 	private boolean isUp;
 	private ColorRGB color;
 	private double diameter=1;
+	
+	//
+	static private int instanceCpt=0;
+	private int instanceNum=instanceCpt++;
+	
+	// 
+	private String name_base = "Turtle_"+instanceNum;
+	
 
 	public Turtle() {
 		super();
@@ -53,6 +61,7 @@ public class Turtle implements Cloneable {
 		for( TurtleMove m : t.history ) {
 			this.history.add(new TurtleMove(m));
 		}
+		this.name_base = t.name_base;
 	}
 	
 	public Turtle(ColorRGB firstColor) {
@@ -77,7 +86,7 @@ public class Turtle implements Cloneable {
 		py = 0;
 		setAngle(0);
 		penUp();
-		history = new ArrayList<TurtleMove>();
+		history = new ArrayList<>();
 		// default turtle color is black.
 		setColor(c);
 	}
@@ -452,5 +461,13 @@ public class Turtle implements Cloneable {
 		}
 		
 		return new ColorRGB(0,0,0);
+	}
+	
+	public String getName(){
+		return name_base;
+	}
+	
+	public void setName(String name){
+		name_base = name +"_"+instanceNum;
 	}
 }


### PR DESCRIPTION
I try to give a name to each instantiation of the class Turtle to (update JFrame title and ) propose a file name during SaveGcode and/or SaveSVG/DXF.

This is a draft version because I have things to review and complete.
* [ ] Generators
* [ ] Converters
* [ ] Keep only the file name (without extension) and not the full path
* [ ] Propose or not to add the date at the end of the file name for the Save*.
* [ ] ...
* [ ] A cleanner way to get the version for SaveGcode

But it allowed me to notice that for a LoadImage, the Wander converter if not in CMYK, does not reset the turtle ... and adds a conversion pass. ( check once CMYK? then unchek it ( the new Wander is cumulated with the one from when CMYK? was checked)