### PR TITLE
💄 Add an option to set a speed accelerator when dragging the preview

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/makelangeloSettingsPanel/GFXPreferences.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makelangeloSettingsPanel/GFXPreferences.java
@@ -3,11 +3,11 @@ package com.marginallyclever.makelangelo.makelangeloSettingsPanel;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.prefs.Preferences;
 
 import com.marginallyclever.makelangelo.Translator;
-import com.marginallyclever.makelangelo.select.SelectBoolean;
-import com.marginallyclever.makelangelo.select.SelectPanel;
+import com.marginallyclever.makelangelo.select.*;
 import com.marginallyclever.util.PreferencesHelper;
 
 /**
@@ -15,45 +15,47 @@ import com.marginallyclever.util.PreferencesHelper;
  * @author Dan Royer
  */
 public class GFXPreferences {
-	static private SelectPanel panel;
 	static private SelectBoolean showPenUp;
 	static private SelectBoolean antialias;
 	static private SelectBoolean speedOverQuality;
 	static private SelectBoolean showAllWhileDrawing;
-	static ArrayList<PropertyChangeListener> listeners = new ArrayList<PropertyChangeListener>(); 
-	
+	static private SelectSpinner dragFactor;
+	static List<PropertyChangeListener> listeners = new ArrayList<PropertyChangeListener>();
+
 	static public void addListener(PropertyChangeListener p) {
 		listeners.add(p);
 	}
-	
+
 	static public void removeListener(PropertyChangeListener p) {
 		listeners.remove(p);
 	}
-	
+
 	static protected void firePropertyChange(PropertyChangeEvent e) {
 		for(PropertyChangeListener p : listeners) {
 			p.propertyChange(e);
 		}
 	}
-	
+
 	static private Preferences getMyNode() {
 		return PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.GRAPHICS);
 	}
 	
 	static public SelectPanel buildPanel() {
 		Preferences prefs = getMyNode();
-		
-		panel = new SelectPanel();
+
+		SelectPanel panel = new SelectPanel();
 		showPenUp = new SelectBoolean("penup",Translator.get("GFXPreferences.showPenUp"),prefs.getBoolean("show pen up", false));
 		antialias = new SelectBoolean("antialias",Translator.get("GFXPreferences.antialias"),prefs.getBoolean("antialias", true));
 		speedOverQuality = new SelectBoolean("SpeedVSQuality",Translator.get("GFXPreferences.speedVSQuality"),prefs.getBoolean("speed over quality", true));
 		showAllWhileDrawing = new SelectBoolean("drawWhileRunning",Translator.get("GFXPreferences.showAllWhileDrawing"),prefs.getBoolean("Draw all while running", true));
+		dragFactor = new SelectSpinner("dragFactor", Translator.get("GFXPreferences.dragFactor"), 1, 5, prefs.getInt("dragFactor", 1));
 
 		panel.add(showPenUp);
 		panel.add(showAllWhileDrawing);
 		panel.add(antialias);
 		panel.add(speedOverQuality);
-		
+		panel.add(dragFactor);
+
 		GFXPreferences.addListener((e)->{
 			showPenUp.setSelected((boolean)e.getNewValue());
 		});
@@ -63,18 +65,19 @@ public class GFXPreferences {
 
 		return panel;
 	}
-	
+
 	static public void save() {
 		Preferences prefs = getMyNode();
 		prefs.putBoolean("show pen up", showPenUp.isSelected());
 		prefs.putBoolean("antialias", antialias.isSelected());
 		prefs.putBoolean("speed over quality", speedOverQuality.isSelected());
 		prefs.putBoolean("Draw all while running", showAllWhileDrawing.isSelected());
+		prefs.putInt("dragFactor", dragFactor.getValue());
 	}
 	
 	static public void cancel() {}
 	
-	static public boolean getShowPenUp() {		
+	static public boolean getShowPenUp() {
 		Preferences prefs = getMyNode();
 		return prefs.getBoolean("show pen up",false);
 	}

--- a/src/main/java/com/marginallyclever/makelangelo/makelangeloSettingsPanel/GFXPreferences.java
+++ b/src/main/java/com/marginallyclever/makelangelo/makelangeloSettingsPanel/GFXPreferences.java
@@ -19,7 +19,7 @@ public class GFXPreferences {
 	static private SelectBoolean antialias;
 	static private SelectBoolean speedOverQuality;
 	static private SelectBoolean showAllWhileDrawing;
-	static private SelectSpinner dragFactor;
+	static private SelectSpinner dragSpeed;
 	static List<PropertyChangeListener> listeners = new ArrayList<PropertyChangeListener>();
 
 	static public void addListener(PropertyChangeListener p) {
@@ -48,13 +48,13 @@ public class GFXPreferences {
 		antialias = new SelectBoolean("antialias",Translator.get("GFXPreferences.antialias"),prefs.getBoolean("antialias", true));
 		speedOverQuality = new SelectBoolean("SpeedVSQuality",Translator.get("GFXPreferences.speedVSQuality"),prefs.getBoolean("speed over quality", true));
 		showAllWhileDrawing = new SelectBoolean("drawWhileRunning",Translator.get("GFXPreferences.showAllWhileDrawing"),prefs.getBoolean("Draw all while running", true));
-		dragFactor = new SelectSpinner("dragFactor", Translator.get("GFXPreferences.dragFactor"), 1, 5, prefs.getInt("dragFactor", 1));
+		dragSpeed = new SelectSpinner("dragSpeed", Translator.get("GFXPreferences.dragSpeed"), 1, 5, prefs.getInt("dragSpeed", 1));
 
 		panel.add(showPenUp);
 		panel.add(showAllWhileDrawing);
 		panel.add(antialias);
 		panel.add(speedOverQuality);
-		panel.add(dragFactor);
+		panel.add(dragSpeed);
 
 		GFXPreferences.addListener((e)->{
 			showPenUp.setSelected((boolean)e.getNewValue());
@@ -72,7 +72,7 @@ public class GFXPreferences {
 		prefs.putBoolean("antialias", antialias.isSelected());
 		prefs.putBoolean("speed over quality", speedOverQuality.isSelected());
 		prefs.putBoolean("Draw all while running", showAllWhileDrawing.isSelected());
-		prefs.putInt("dragFactor", dragFactor.getValue());
+		prefs.putInt("dragSpeed", dragSpeed.getValue());
 	}
 	
 	static public void cancel() {}

--- a/src/main/java/com/marginallyclever/makelangelo/preview/Camera.java
+++ b/src/main/java/com/marginallyclever/makelangelo/preview/Camera.java
@@ -1,5 +1,7 @@
 package com.marginallyclever.makelangelo.preview;
 
+import com.marginallyclever.util.PreferencesHelper;
+
 /**
  * All information about the position and zoom level of the virtual eye looking through the PreviewPanel at the robot/art
  * @author Dan Royer
@@ -18,18 +20,18 @@ public class Camera {
 	// window size (for aspect ratio?)
 	private double width, height;
 
-
 	public Camera() {}
-	
-	
+
 	/**
 	 * Reposition the camera
 	 * @param dx change horizontally
 	 * @param dy change vertically
 	 */
 	public void moveRelative(int dx, int dy) {
-		offsetX += (float) dx * zoom / width;
-		offsetY += (float) dy * zoom / height;
+		int scale = PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.GRAPHICS).getInt("dragFactor", 1);
+
+		offsetX += (float) dx * zoom * scale / width;
+		offsetY += (float) dy * zoom * scale / height;
 	}
 
 	private void limitCameraZoom() {
@@ -43,34 +45,29 @@ public class Camera {
 		limitCameraZoom();
 	}
 
-
 	// scale the picture of the robot to fake a zoom.
 	public void zoomOut() {
 		zoom /= ZOOM_STEP_SIZE;
 		limitCameraZoom();
 	}
 
-	
 	// scale the picture of the robot to fake a zoom.
 	public void zoomToFit(double w,double h) {
-		zoom = (w > h ? w : h)/2.0;
+		zoom = (Math.max(w, h))/2.0;
 		limitCameraZoom();
 		
 		offsetX = 0;
 		offsetY = 0;
 	}
 
-
 	public double getX() {
 		return offsetX;
 	}
-	
-	
+
 	public double getY() {
 		return offsetY;
 	}
-	
-	
+
 	public double getZoom() {
 		return zoom;
 	}
@@ -79,16 +76,13 @@ public class Camera {
 		return width;
 	}
 
-
 	public void setWidth(double width) {
 		this.width = width;
 	}
 
-
 	public double getHeight() {
 		return height;
 	}
-
 
 	public void setHeight(double height) {
 		this.height = height;

--- a/src/main/java/com/marginallyclever/makelangelo/preview/Camera.java
+++ b/src/main/java/com/marginallyclever/makelangelo/preview/Camera.java
@@ -28,7 +28,7 @@ public class Camera {
 	 * @param dy change vertically
 	 */
 	public void moveRelative(int dx, int dy) {
-		int scale = PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.GRAPHICS).getInt("dragFactor", 1);
+		int scale = PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.GRAPHICS).getInt("dragSpeed", 1);
 
 		offsetX += (float) dx * zoom * scale / width;
 		offsetY += (float) dy * zoom * scale / height;

--- a/src/main/java/com/marginallyclever/makelangelo/preview/PreviewPanel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/preview/PreviewPanel.java
@@ -272,7 +272,7 @@ public class PreviewPanel extends GLJPanel implements GLEventListener {
 		animator.stop();
 	}
 
-	public void setCamera(Camera camera2) {
-		camera = camera2;
+	public void setCamera(Camera camera) {
+		this.camera = camera;
 	}
 }

--- a/src/main/java/com/marginallyclever/makelangelo/select/SelectPanel.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/SelectPanel.java
@@ -5,6 +5,7 @@ import java.awt.Dimension;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
@@ -44,7 +45,7 @@ public class SelectPanel extends JPanel implements PropertyChangeListener {
 	}
 	
 	// OBSERVER PATTERN	
-	private ArrayList<SelectPanelChangeListener> listeners = new ArrayList<SelectPanelChangeListener>();
+	private List<SelectPanelChangeListener> listeners = new ArrayList<SelectPanelChangeListener>();
 
 	public void removeSelectPanelChangeListener(SelectPanelChangeListener ear) {
 		listeners.remove(ear);
@@ -87,6 +88,7 @@ public class SelectPanel extends JPanel implements PropertyChangeListener {
 		SelectReadOnlyText h = new SelectReadOnlyText("H","H "+ipsum);
 		SelectSlider i = new SelectSlider("I","I",200,0,100);
 		SelectTextArea j = new SelectTextArea("J","J",ipsum);
+		SelectSpinner k = new SelectSpinner("K", "K", 1, 10, 3);
 		
 		panel.add(a);
 		panel.add(b);
@@ -98,7 +100,8 @@ public class SelectPanel extends JPanel implements PropertyChangeListener {
 		panel.add(h);
 		panel.add(i);
 		panel.add(j);
-		
+		panel.add(k);
+
 		// test finish
 		panel.setPreferredSize(new Dimension(400,600));
 		

--- a/src/main/java/com/marginallyclever/makelangelo/select/SelectSpinner.java
+++ b/src/main/java/com/marginallyclever/makelangelo/select/SelectSpinner.java
@@ -1,0 +1,40 @@
+package com.marginallyclever.makelangelo.select;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SelectSpinner extends Select {
+
+    private JLabel label;
+    private JSpinner field;
+
+    public SelectSpinner(String name, String labelText, int min, int max, int value) {
+        super(name);
+
+        label = new JLabel(labelText,JLabel.LEADING);
+
+        List<Integer> list = new ArrayList<>();
+        for (int i = min; i<= max; i++) {
+            list.add(i);
+        }
+        field = new JSpinner(new SpinnerListModel(list));
+
+        Dimension d = field.getPreferredSize();
+        d.width = 50;
+        field.setPreferredSize(d);
+        field.setValue(value);
+
+        this.add(label, BorderLayout.LINE_START);
+        this.add(field,BorderLayout.LINE_END);
+    }
+
+    public int getValue() {
+        return (int) field.getValue();
+    }
+
+    public void setValue(int v) {
+        field.setValue(v);
+    }
+}

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -581,8 +581,8 @@
 		<hint>graphics settings dialog</hint>
 	</string>
 	<string>
-		<key>GFXPreferences.dragFactor</key>
-		<value>Speed of moving while dragging</value>
+		<key>GFXPreferences.dragSpeed</key>
+		<value>camera travel speed</value>
 		<hint>graphics settings dialog</hint>
 	</string>
 	<string>

--- a/src/main/resources/languages/english.xml
+++ b/src/main/resources/languages/english.xml
@@ -581,6 +581,11 @@
 		<hint>graphics settings dialog</hint>
 	</string>
 	<string>
+		<key>GFXPreferences.dragFactor</key>
+		<value>Speed of moving while dragging</value>
+		<hint>graphics settings dialog</hint>
+	</string>
+	<string>
 		<key>MenuLanguageTitle</key>
 		<value>Language</value>
 		<hint>menu or dialog title</hint>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -528,6 +528,11 @@
         <hint>[graphics settings dialog]</hint>
     </string>
     <string>
+        <key>GFXPreferences.dragFactor</key>
+        <value>Vitesse de déplacement de la souris</value>
+        <hint>graphics settings dialog</hint>
+    </string>
+    <string>
         <key>Invert</key>
         <value>Inverser</value>
         <hint>[jog motors dialog]</hint>

--- a/src/main/resources/languages/french.xml
+++ b/src/main/resources/languages/french.xml
@@ -528,7 +528,7 @@
         <hint>[graphics settings dialog]</hint>
     </string>
     <string>
-        <key>GFXPreferences.dragFactor</key>
+        <key>GFXPreferences.dragSpeed</key>
         <value>Vitesse de déplacement de la souris</value>
         <hint>graphics settings dialog</hint>
     </string>


### PR DESCRIPTION
When click + drag on the preview pane to move the preview, I need to move the mouse a lot.

Here is a new option to configure it. By default, the value is the same as today: `1`.
![image](https://user-images.githubusercontent.com/23615562/156944691-5d39d9a9-ef6a-4db8-bc85-f89c26661d47.png)

On my computer, I set it to 4 to have a good feeling.