### PR TITLE
remove the filter for serial connections on mac to return all the values possible. Useful for socat.

### DIFF
--- a/src/main/java/com/marginallyclever/communications/serial/SerialTransportLayer.java
+++ b/src/main/java/com/marginallyclever/communications/serial/SerialTransportLayer.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 public class SerialTransportLayer implements TransportLayer {
 
 	private static final Logger logger = LoggerFactory.getLogger(SerialTransportLayer.class);
+	public static final String CU_USBSERIAL = "cu.usbserial";
 
 	public SerialTransportLayer() {}
 
@@ -34,24 +35,21 @@ public class SerialTransportLayer implements TransportLayer {
 		String[] portsDetected;
 
 		String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		portsDetected = SerialPortList.getPortNames();
 		if ((os.contains("mac")) || (os.contains("darwin"))) {
 			// Also list Bluetooth serial connections
-			portsDetected = SerialPortList.getPortNames(Pattern.compile("cu"));
-
 			Arrays.sort(portsDetected, (o1, o2) -> {
 				// cu.usbserial* are most used, so put it on the top of the list
-				if (o1.contains("cu.usbserial") && o2.contains("cu.usbserial")) {
+				if (o1.contains(CU_USBSERIAL) && o2.contains(CU_USBSERIAL)) {
 					return o1.compareTo(o2);
 				}
-				if (o2.contains("cu.usbserial")) {
+				if (o2.contains(CU_USBSERIAL)) {
 					return 1;
-				} else if (o1.contains("cu.usbserial")) {
+				} else if (o1.contains(CU_USBSERIAL)) {
 					return -1;
 				}
 				return o1.compareTo(o2);
 			});
-		} else {
-			portsDetected = SerialPortList.getPortNames();
 		}
 
 		List<String> connections = Arrays.asList(portsDetected);

--- a/src/test/java/com/marginallyclever/communications/SerialTransportLayerTest.java
+++ b/src/test/java/com/marginallyclever/communications/SerialTransportLayerTest.java
@@ -20,13 +20,14 @@ public class SerialTransportLayerTest {
 
 		try (MockedStatic<SerialPortList> serialPortListMocked = Mockito.mockStatic(SerialPortList.class)) {
 			System.setProperty("os.name", "mac");
-			serialPortListMocked.when(() -> SerialPortList.getPortNames(any(Pattern.class))).thenReturn(new String[]{"/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33", "/dev/cu.usbserial-1444140", "/dev/cu.usbserial-1410"});
+			serialPortListMocked.when(SerialPortList::getPortNames).thenReturn(new String[]{"/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33", "/dev/cu.usbserial-1444140", "/dev/cu.usbserial-1410", "/dev/tty1", "/dev/ttys1"});
 			List<String> connectionNames = new SerialTransportLayer().listConnections();
-			assertEquals(List.of("/dev/cu.usbserial-1410", "/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33"), connectionNames);
+			assertEquals(List.of("/dev/cu.usbserial-1410", "/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33", "/dev/tty1", "/dev/ttys1"), connectionNames);
 
-			serialPortListMocked.when(() -> SerialPortList.getPortNames(any(Pattern.class))).thenReturn(new String[]{"/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33", "/dev/cu.usbserial-1410"});
+			// alternate order
+			serialPortListMocked.when(SerialPortList::getPortNames).thenReturn(new String[]{"/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/tty1", "/dev/cu.SRS-XB33", "/dev/ttys1", "/dev/cu.usbserial-1410"});
 			connectionNames = new SerialTransportLayer().listConnections();
-			assertEquals(List.of("/dev/cu.usbserial-1410", "/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33"), connectionNames);
+			assertEquals(List.of("/dev/cu.usbserial-1410", "/dev/cu.usbserial-1444140", "/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.SRS-XB33", "/dev/tty1", "/dev/ttys1"), connectionNames);
 		} finally {
 			System.setProperty("os.name", osName);
 		}


### PR DESCRIPTION
Asked on discord by @Mieg : 
> I tried setting up a 'virtual' serial device on my macbook using socat, and that does work - but Makelangelo doesn't see it because the device name doesn't start with /dev/tty. or /dev/cu.