### PR TITLE
Donatello preview integration with nodes.

### DIFF
--- a/src/main/java/com/marginallyclever/makelangelo/donatelloimpl/nodes/CanvasFromPreview.java
+++ b/src/main/java/com/marginallyclever/makelangelo/donatelloimpl/nodes/CanvasFromPreview.java
@@ -1,0 +1,93 @@
+package com.marginallyclever.makelangelo.donatelloimpl.nodes;
+
+import com.marginallyclever.donatello.ports.InputColor;
+import com.marginallyclever.donatello.ports.InputInt;
+import com.marginallyclever.donatello.ports.OutputInt;
+import com.marginallyclever.nodegraphcore.Node;
+import com.marginallyclever.nodegraphcore.PrintWithGraphics;
+import com.marginallyclever.util.PreferencesHelper;
+
+import java.awt.*;
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+
+import static com.marginallyclever.makelangelo.paper.Paper.*;
+
+/**
+ * A node that creates a canvas with a given size and color.
+ */
+public class CanvasFromPreview extends Node implements PrintWithGraphics {
+    private Integer width = 1;
+    private Integer height = 1;
+    private Color color = Color.WHITE;
+
+    private double paperLeft;
+    private double paperRight;
+    private double paperBottom;
+    private double paperTop;
+
+    private final InputInt layer = new InputInt("layer", 0);
+    private final OutputInt outx = new OutputInt("x", 0);
+    private final OutputInt outy = new OutputInt("y", 0);
+    private final OutputInt outw = new OutputInt("width out", width);
+    private final OutputInt outh = new OutputInt("height out", height);
+
+    private static final Preferences paperPreferenceNode
+            = PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.PAPER);
+
+    private void readConfig() {
+        paperLeft = Double.parseDouble(paperPreferenceNode.get(PREF_KEY_PAPER_LEFT, Double.toString(paperLeft)));
+        paperRight = Double.parseDouble(paperPreferenceNode.get(PREF_KEY_PAPER_RIGHT, Double.toString(paperRight)));
+        paperTop = Double.parseDouble(paperPreferenceNode.get(PREF_KEY_PAPER_TOP, Double.toString(paperTop)));
+        paperBottom = Double.parseDouble(paperPreferenceNode.get(PREF_KEY_PAPER_BOTTOM, Double.toString(paperBottom)));
+
+        int colorFromPref = Integer.parseInt(paperPreferenceNode.get(PREF_KEY_PAPER_COLOR, Integer.toString(color.hashCode())));
+        color = new Color(colorFromPref);
+
+        width = (int) (-paperLeft + paperRight);
+        height = (int) (paperTop - paperBottom);
+    }
+
+    public CanvasFromPreview() {
+        super("Canvas");
+
+        readConfig();
+
+        paperPreferenceNode.addPreferenceChangeListener(evt -> readConfig());
+
+        addPort(outx);
+        addPort(outy);
+        addPort(outw);
+        addPort(outh);
+        addPort(layer);
+    }
+
+    @Override
+    public void update() {
+        readConfig();
+
+        var w = Math.max(1, width);
+        var h = Math.max(1, height);
+        outx.setValue(-w / 2);
+        outy.setValue(-h / 2);
+        outw.setValue(w);
+        outh.setValue(h);
+    }
+
+
+    @Override
+    public void print(Graphics g) {
+        var x = outx.getValue();
+        var y = outy.getValue();
+        var w = Math.max(1, width);
+        var h = Math.max(1, height);
+        g.setColor(color);
+        g.fillRect(x, y, w, h);
+    }
+
+    @Override
+    public int getLayer() {
+        return layer.getValue();
+    }
+}

--- a/src/main/java/com/marginallyclever/makelangelo/donatelloimpl/nodes/turtle/TurtleToPreview.java
+++ b/src/main/java/com/marginallyclever/makelangelo/donatelloimpl/nodes/turtle/TurtleToPreview.java
@@ -1,0 +1,92 @@
+package com.marginallyclever.makelangelo.donatelloimpl.nodes.turtle;
+
+import com.marginallyclever.donatello.Donatello;
+import com.marginallyclever.donatello.ports.InputBoolean;
+import com.marginallyclever.donatello.ports.InputColor;
+import com.marginallyclever.donatello.ports.InputInt;
+import com.marginallyclever.donatello.ports.InputOneOfMany;
+import com.marginallyclever.makelangelo.MainFrame;
+import com.marginallyclever.makelangelo.donatelloimpl.ports.InputTurtle;
+import com.marginallyclever.makelangelo.makeart.turtlegenerator.Generator_AnalogClock;
+import com.marginallyclever.makelangelo.makeart.turtlegenerator.TurtleGeneratorFactory;
+import com.marginallyclever.makelangelo.makeart.turtlegenerator.lineweight.GenerateClockHands;
+import com.marginallyclever.makelangelo.preview.PreviewPanel;
+import com.marginallyclever.makelangelo.turtle.PolylineBuilder;
+import com.marginallyclever.makelangelo.turtle.Turtle;
+import com.marginallyclever.makelangelo.turtle.TurtleToBufferedImageHelper;
+import com.marginallyclever.makelangelo.turtle.turtlerenderer.TurtleRenderFacade;
+import com.marginallyclever.makelangelo.turtle.turtlerenderer.TurtleRenderFactory;
+import com.marginallyclever.makelangelo.turtle.turtlerenderer.TurtleRenderer;
+import com.marginallyclever.nodegraphcore.Node;
+import com.marginallyclever.nodegraphcore.PrintWithGraphics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * <p>Print the {@link Turtle}'s path behind the {@link Node}s.</p>
+ * <p>On {@link #update()} pass over the {@link Turtle} once and build a list of polylines for faster rendering.
+ * This is done using a {@link PolylineBuilder} which also optimizes to remove points on nearly straight lines.</p>
+ */
+public class TurtleToPreview extends Node implements PrintWithGraphics {
+    private static final Logger logger = LoggerFactory.getLogger(TurtleToPreview.class);
+
+    private final InputTurtle turtle = new InputTurtle("turtle");
+    private final InputInt layer = new InputInt("layer",5);
+    private final InputOneOfMany style = new InputOneOfMany("style");
+
+    private PreviewPanel previewPanel;
+
+    public TurtleToPreview() {
+        super("TurtleToPreview");
+        addPort(turtle);
+        addPort(style);
+        addPort(layer);
+
+        style.setOptions(TurtleRenderFactory.getNames());
+    }
+
+    public static JFrame getActiveJFrame() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof JFrame && window.isVisible()) {
+                return (JFrame) window;
+            }
+        }
+        return null; // No visible JFrame found
+    }
+
+    @Override
+    public void update() {
+        setComplete(0);
+
+        MainFrame frame = (MainFrame)SwingUtilities.getRoot(getActiveJFrame());
+        previewPanel = frame.getPreviewPanel();
+
+        setComplete(100);
+    }
+
+    @Override
+    public int getLayer() {
+        return layer.getValue();
+    }
+
+    @Override
+    public void print(Graphics g) {
+
+        Turtle turtle1 = this.turtle.getValue();
+
+        if(previewPanel != null && turtle1 != null) {
+            previewPanel.setTurtle(turtle1);
+
+        } else {
+            logger.debug("Invalid turtle or preview panel");
+        }
+    }
+
+}

--- a/src/main/java/com/marginallyclever/makelangelo/paper/Paper.java
+++ b/src/main/java/com/marginallyclever/makelangelo/paper/Paper.java
@@ -16,15 +16,15 @@ public class Paper implements PreviewListener {
 	public static final int DEFAULT_WIDTH = 420; // mm
 	public static final int DEFAULT_HEIGHT = 594; // mm
 
-	private static final String PREF_KEY_ROTATION = "rotation";
-	private static final String PREF_KEY_PAPER_MARGIN = "paper_margin";
-	private static final String PREF_KEY_PAPER_BOTTOM = "paper_bottom";
-	private static final String PREF_KEY_PAPER_TOP = "paper_top";
-	private static final String PREF_KEY_PAPER_RIGHT = "paper_right";
-	private static final String PREF_KEY_PAPER_LEFT = "paper_left";
-	private static final String PREF_KEY_PAPER_COLOR = "paper_color";
-	private static final String PREF_KEY_PAPER_CENTER_X = "paper_center_X";
-	private static final String PREF_KEY_PAPER_CENTER_Y = "paper_center_Y";
+	public static final String PREF_KEY_ROTATION = "rotation";
+	public static final String PREF_KEY_PAPER_MARGIN = "paper_margin";
+	public static final String PREF_KEY_PAPER_BOTTOM = "paper_bottom";
+	public static final String PREF_KEY_PAPER_TOP = "paper_top";
+	public static final String PREF_KEY_PAPER_RIGHT = "paper_right";
+	public static final String PREF_KEY_PAPER_LEFT = "paper_left";
+	public static final String PREF_KEY_PAPER_COLOR = "paper_color";
+	public static final String PREF_KEY_PAPER_CENTER_X = "paper_center_X";
+	public static final String PREF_KEY_PAPER_CENTER_Y = "paper_center_Y";
 
 	private static final Preferences paperPreferenceNode
 		= PreferencesHelper.getPreferenceNode(PreferencesHelper.MakelangeloPreferenceKey.PAPER);


### PR DESCRIPTION
# Description

I have implemented two new nodes.

**CanvasFromPreview** creates a canvas using data from the Paper preference. 

**TurtleToPreview** pipes the turtle input into the preview renderer. That range slider works great.

Fixes #835

## Type of change

- [ ] Add two new nodes

# How Has This Been Tested?

- [ ] Created various nodes and graphs. See the screenshot

![java_MXJR6b0YoV](https://github.com/user-attachments/assets/99c73118-4fa7-4026-a364-cef83d3056d1)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
